### PR TITLE
dont burn your printer down...

### DIFF
--- a/VORON-0/Firmware/printer.cfg
+++ b/VORON-0/Firmware/printer.cfg
@@ -109,7 +109,7 @@ sense_resistor: 0.110
 stealthchop_threshold: 500
 
 [heater_bed]
-heater_pin: !PC12
+heater_pin: PC12
 sensor_type: NTC 100K 3950
 #sensor_type: NTC 100K MGB18-104F39050L32
 sensor_pin: PC3


### PR DESCRIPTION
inverted bed heater to stop run away heating on startup