### PR TITLE
Uncomment required lines from bed heater section

### DIFF
--- a/VORON-0/Firmware/printer.cfg
+++ b/VORON-0/Firmware/printer.cfg
@@ -116,12 +116,12 @@ sensor_type: NTC 100K 3950
 sensor_pin: PC3
 smooth_time: 3.0
 max_power: 1.0
-#control: pid
+control: pid
 min_temp: 0
 max_temp: 120
-#pid_kp: 58.437
-#pid_ki: 2.347
-#pid_kd: 363.769
+pid_kp: 58.437
+pid_ki: 2.347
+pid_kd: 363.769
 
 [printer]
 kinematics: corexy


### PR DESCRIPTION
In the previous commit, the `SAVE_CONFIG` block was (probably correctly) deleted, which overrode the commented-out heater settings for the heater bed; this breaks the config for people doing a fresh start. This commit uncomments the control section so folks can get started without tripping up on this 🙂

_sigh_, you'd think I'd realize I didn't actually _open_ the PR the other day... 🤦 