### PR TITLE
Updates PRINT_END to keep nozzle within boundaries

### DIFF
--- a/VORON-0/Firmware/printer.cfg
+++ b/VORON-0/Firmware/printer.cfg
@@ -184,15 +184,29 @@ gcode:
     G28                            ; home all axes
     G1 Z20 F3000                   ; move nozzle away from bed
    
-
 [gcode_macro PRINT_END]
 #   Use PRINT_END for the slicer ending script - please customise for your slicer of choice
 gcode:
+
     M400                           ; wait for buffer to clear
     G92 E0                         ; zero the extruder
     G1 E-4.0 F3600                 ; retract filament
     G91                            ; relative positioning
-    G0 Z1.00 X20.0 Y20.0 F20000    ; move nozzle to remove stringing
+
+    #   Check end position to determine safe direction to move
+    {% if printer.toolhead.position.x < 100 %}
+        {% set x_safe = 20.0 %}
+    {% else %}
+        {% set x_safe = -20.0 %}
+    {% endif %}
+
+    {% if printer.toolhead.position.y < 100 %}
+        {% set y_safe = 20.0 %}
+    {% else %}
+        {% set y_safe = -20.0 %}
+    {% endif %}
+
+    G0 Z1.00 X{x_safe} Y{y_safe} F20000    ; move nozzle to remove stringing
     TURN_OFF_HEATERS
     M107                           ; turn off fan
     G1 Z2 F3000                    ; move nozzle up 2mm

--- a/VORON-0/Firmware/printer.cfg
+++ b/VORON-0/Firmware/printer.cfg
@@ -187,7 +187,6 @@ gcode:
 [gcode_macro PRINT_END]
 #   Use PRINT_END for the slicer ending script - please customise for your slicer of choice
 gcode:
-
     M400                           ; wait for buffer to clear
     G92 E0                         ; zero the extruder
     G1 E-4.0 F3600                 ; retract filament

--- a/VORON-0/Firmware/printer.cfg
+++ b/VORON-0/Firmware/printer.cfg
@@ -217,7 +217,8 @@ gcode:
         {% set z_safe = max_z - printer.toolhead.position.z %}
     {% endif %}
 
-    G0 Z{z_safe} X{x_safe} Y{y_safe} F20000    ; move nozzle to remove stringing
+    G0 Z{z_safe} F3600    ; move nozzle up
+    G0 X{x_safe} Y{y_safe} F20000    ; move nozzle to remove stringing
     TURN_OFF_HEATERS
     M107                           ; turn off fan
     G90                            ; absolute positioning

--- a/VORON-0/Firmware/printer.cfg
+++ b/VORON-0/Firmware/printer.cfg
@@ -187,30 +187,41 @@ gcode:
 [gcode_macro PRINT_END]
 #   Use PRINT_END for the slicer ending script - please customise for your slicer of choice
 gcode:
+
     M400                           ; wait for buffer to clear
     G92 E0                         ; zero the extruder
     G1 E-4.0 F3600                 ; retract filament
     G91                            ; relative positioning
 
+    #   Get Boundaries
+    {% set max_x = printer.configfile.config["stepper_x"]["position_max"]|float %}
+    {% set max_y = printer.configfile.config["stepper_y"]["position_max"]|float %}
+    {% set max_z = printer.configfile.config["stepper_z"]["position_max"]|float %}
+
     #   Check end position to determine safe direction to move
-    {% if printer.toolhead.position.x < 100 %}
+    {% if printer.toolhead.position.x < (max_x - 20) %}
         {% set x_safe = 20.0 %}
     {% else %}
         {% set x_safe = -20.0 %}
     {% endif %}
 
-    {% if printer.toolhead.position.y < 100 %}
+    {% if printer.toolhead.position.y < (max_y - 20) %}
         {% set y_safe = 20.0 %}
     {% else %}
         {% set y_safe = -20.0 %}
     {% endif %}
 
-    G0 Z1.00 X{x_safe} Y{y_safe} F20000    ; move nozzle to remove stringing
+    {% if printer.toolhead.position.z < (max_z - 2) %}
+        {% set z_safe = 2.0 %}
+    {% else %}
+        {% set z_safe = max_z - printer.toolhead.position.z %}
+    {% endif %}
+
+    G0 Z{z_safe} X{x_safe} Y{y_safe} F20000    ; move nozzle to remove stringing
     TURN_OFF_HEATERS
     M107                           ; turn off fan
-    G1 Z2 F3000                    ; move nozzle up 2mm
     G90                            ; absolute positioning
-    G0  X60 Y120 F3600            ; park nozzle at rear
+    G0 X60 Y{max_y} F3600          ; park nozzle at rear
 	
 [gcode_macro LOAD_FILAMENT]
 gcode:


### PR DESCRIPTION
Adds a check for X and Y at print end to determine safe direction to move nozzle to remove stringing.  Without this, larger prints on the V0 will throw an outside boundaries error when running the PRINT_END macro.