### PR TITLE
config error: [heater_bed]

### DIFF
--- a/VORON-0/Firmware/printer.cfg
+++ b/VORON-0/Firmware/printer.cfg
@@ -111,7 +111,7 @@ stealthchop_threshold: 500
 
 [heater_bed]
 heater_pin: PC12
-sensor_type: NTC 100K 3950
+sensor_type: NTC 100K beta 3950
 #sensor_type: NTC 100K MGB18-104F39050L32
 sensor_pin: PC3
 smooth_time: 3.0


### PR DESCRIPTION
changed "NTC 100K 3950", which doesn't actually exist, to "NTC 100K beta 3950" which does.