### PR TITLE
updated printer.cfg

### DIFF
--- a/VORON-0/Firmware/printer.cfg
+++ b/VORON-0/Firmware/printer.cfg
@@ -115,7 +115,7 @@ sensor_type: NTC 100K 3950
 #sensor_type: NTC 100K MGB18-104F39050L32
 sensor_pin: PC3
 smooth_time: 3.0
-max_power: 1.0
+max_power: 0.6
 control: pid
 min_temp: 0
 max_temp: 120
@@ -192,7 +192,6 @@ gcode:
     G92 E0                         ; zero the extruder
     G1 E-4.0 F3600                 ; retract filament
     G91                            ; relative positioning
-    G0 Z1.00 X20.0 Y20.0 F20000    ; move nozzle to remove stringing
     TURN_OFF_HEATERS
     M107                           ; turn off fan
     G1 Z2 F3000                    ; move nozzle up 2mm


### PR DESCRIPTION
heater_bed
max_power change from 1.0 to 0.6 for appropriate heating speeds

in macro PRINT_END
removed relative move for X and Y to avoid out of bound X/Y moves on large parts