### PR TITLE
Fixes bedScrewMenu.cfg for V0 displays

### DIFF
--- a/VORON-0/Firmware/bedScrewMenu.cfg
+++ b/VORON-0/Firmware/bedScrewMenu.cfg
@@ -1,27 +1,16 @@
 # This config requires a display of some type attached to the printer.
 
 ### menu prepare ###
-[menu __prepare]
+[menu __main __prepare]
 type: list
-enable: !toolhead.is_printing
+enable: {not printer.idle_timeout.state == "Printing"}
 name: Prepare
-items:
-	.__bedScrew
-    .__hotend_pid_tuning
-    .__hotbed_pid_tuning
-    .__host_restart
-    .__firmware_restart
-	
-[menu __prepare __bedScrew]  
+
+[menu __main __prepare __bedScrew]  
 type: list
 name: Bed Screw Tune
-items:
-    .__Start
-    .__Accept
-    .__Adjusted
-    .__Abort
 
-[menu __prepare __bedScrew __Start]
+[menu __main __prepare __bedScrew __Start]
 type:command
 name: Start Screw Adjust
 gcode:
@@ -29,19 +18,19 @@ gcode:
 	G28 Z0
     BED_SCREWS_ADJUST
 
-[menu __prepare __bedScrew __Accept]
+[menu __main __prepare __bedScrew __Accept]
 type:command
 name: Accept  	
 gcode:
     ACCEPT
 
-[menu __prepare __bedScrew __Adjusted]
+[menu __main __prepare __bedScrew __Adjusted]
 type:command
 name: Adjusted
 gcode:
     ADJUSTED
 
-[menu __prepare __bedScrew __Abort]
+[menu __main __prepare __bedScrew __Abort]
 type:command
 name: Abort
 gcode:


### PR DESCRIPTION
Removed the invalid `items` property and fixed the menu structure and `enable` flag so that the bed screw menu works properly with a display.  In the current state, it throws an error.