### PR TITLE
Changes cycle_time for parts fan

### DIFF
--- a/VORON-0/Firmware/printer.cfg
+++ b/VORON-0/Firmware/printer.cfg
@@ -148,7 +148,7 @@ kick_start_time: 0.5
 #depending on your fan, you may need to increase or reduce this value
 #if your fan will not start
 off_below: 0.13
-cycle_time: 0.001
+cycle_time: 0.010
 
 [idle_timeout]
 timeout: 1800


### PR DESCRIPTION
Changes the cycle_time value for the parts fan to `0.010` which is the default value.  The previous value of `0.001` would not work reliably with some fans.