### PR TITLE
Update printer.cfg

### DIFF
--- a/Firmware/printer.cfg
+++ b/Firmware/printer.cfg
@@ -141,8 +141,8 @@ pid_kd: 426.122
 
 [printer]
 kinematics: corexy
-max_velocity: 300
-max_accel: 4000
+max_velocity: 200
+max_accel: 2000
 max_z_velocity: 15
 max_z_accel: 45
 square_corner_velocity: 6.0


### PR DESCRIPTION
Reduce speed and accels in printer.cfg. A couple of users on the discord have had issues with skipping on moves immediately after the home routine, and turning down the speeds and accels has solved this. Having a printer work from the get go, i would say is of prime importance, and tuning for silly speeds later should be a choice they can make, not something that causes them issues.

One user is using the BOM OMC stepper online motors and is now running above the values i have set. The other user i'm currently aware of with the same issue, is running cheaper chinese kit motors, and is running a lower value in speed and accels 150/1500. I will attempt to get them to leave comments here.

Thank you Github cherrubs! Hopefully this time i haven't somehow created a file in the root of the repo...