### PR TITLE
turn stealthchop off extruder

### DIFF
--- a/Firmware/printer.cfg
+++ b/Firmware/printer.cfg
@@ -127,7 +127,7 @@ hold_current: 0.2	# for LDO 36STH17-1004AHG
 #run_current: 0.5	# for OMC 14HR07-1004VRN rated at 1A
 #hold_current: 0.3	# for OMC 14HR07-1004VRN rated at 1A
 sense_resistor: 0.110
-stealthchop_threshold: 500
+stealthchop_threshold: 0
 
 
 [heater_bed]


### PR DESCRIPTION
I have observed in Discord a bunch of folks with extruder skipping issues still running the default "500" `stealthchop_threshold` value which essentially sets the extruder stealthchop to "always on". Turning it off / setting to 0 has fixed issues for a couple folks. I believe this is de rigueur to leave it off on the pancake steppers in any event, afaik ymmv.

Partially resolve #128  