### PR TITLE
Update printer.cfg

### DIFF
--- a/Firmware/printer.cfg
+++ b/Firmware/printer.cfg
@@ -9,140 +9,22 @@
 # file named "firmware.bin" on an SD card and then restart the SKR
 # mini with that SD card.
 
-# See the example.cfg file for a description of available parameters.
+## Voron Design VORON 0.1 SKR Mini E3 V2 config
+
+## *** THINGS TO CHANGE/CHECK: ***
+## MCU path										[mcu] section
+## Z Motor currents								[tmc2209 stepper_z] section
+## Thermistor types								[extruder] and [heater_bed] sections - See 'sensor types' list at end of file
+## Extruder motor currents						[extruder] section
+## PID tune										[extruder] and [heater_bed] sections
+## Fine tune E steps							[extruder] section
+## For more info								check https://docs.vorondesign.com/build/startup/#v0
 
 [mcu]
-##	Obtain mcu value by "ls -l /dev/serial/by-id/" 
-#serial: /dev/serial/by-id/usb-Klipper_stm32f103xe_REPLACE_WITH_YOUR_VALUE
-
-
-[stepper_x]
-step_pin: PB13
-dir_pin: PB12           # check https://docs.vorondesign.com/build/startup/#v0 if moving in the wrong direction
-enable_pin: !PB14
-rotation_distance: 40
-microsteps: 16
-endstop_pin: PC0 
-position_endstop: 120
-position_max: 120
-homing_speed: 20        # Increase after initial setup, Max 100
-homing_retract_dist: 5
-homing_positive_dir: true
-
-[tmc2209 stepper_x]
-uart_pin: PC11
-tx_pin: PC10
-uart_address: 0
-interpolate: True
-run_current: 0.5        # For V0.1 spec NEMA14 40Ncm
-hold_current: 0.25
-sense_resistor: 0.110
-stealthchop_threshold: 0
-
-
-[stepper_y]
-step_pin: PB10
-dir_pin: PB2            # check https://docs.vorondesign.com/build/startup/#v0 if moving in the wrong direction
-enable_pin: !PB11
-rotation_distance: 40
-microsteps: 16
-endstop_pin: PC1
-position_endstop: 120
-position_max: 120
-homing_speed: 20        # Increase after initial setup, Max 100
-homing_retract_dist: 5
-homing_positive_dir: true
-
-[tmc2209 stepper_y]
-uart_pin: PC11
-tx_pin: PC10
-uart_address: 2
-interpolate: True
-run_current: 0.5        # For V0.1 spec NEMA14 40Ncm
-hold_current: 0.25
-sense_resistor: 0.110
-stealthchop_threshold: 0
-
-
-[stepper_z]
-step_pin: PB0
-dir_pin: !PC5           # Remove ! if moving opposite direction
-enable_pin: !PB1
-rotation_distance: 8    # For T8x8 integrated lead screw
-microsteps: 16
-endstop_pin: PC2
-position_endstop: -0.10
-position_max: 120
-position_min: -1.5
-homing_speed: 10        # Max 100
-second_homing_speed: 3.0
-homing_retract_dist: 3.0
-
-[tmc2209 stepper_z]
-uart_pin: PC11
-tx_pin: PC10
-uart_address: 1
-interpolate: True
-#run_current: 0.37       # For V0.1 spec NEMA17 LDO-42STH25-1004CL200E 1.0A  
-#hold_current: 0.35
-run_current: 0.2         # For V0.1 spec NEMA17 OMC 17LS13-0404E-200G 0.4A 
-hold_current: 0.15
-sense_resistor: 0.110
-stealthchop_threshold: 0
-
-
-[extruder]
-step_pin: PB3
-dir_pin: PB4            # Add ! if moving opposite direction
-enable_pin: !PD2
-full_steps_per_rotation: 200    # 1.8° motor LDO
-#full_steps_per_rotation: 400    # 0.9° motor i.e OMC 14HR07-1004VRN
-rotation_distance: 22.23        # See calibrating rotation_distance on extruders doc
-gear_ratio: 50:10               # For Mini Afterburner
-microsteps: 16
-nozzle_diameter: 0.400
-filament_diameter: 1.750
-heater_pin: PC8
-sensor_type: EPCOS 100K B57560G104F # Adjust for your hotend thermistor (see options below)
-sensor_pin: PA0
-control: pid            # Do PID calibration
-pid_Kp: 28.182
-pid_Ki: 1.978
-pid_Kd: 100.397
-min_temp: 0
-max_temp: 270
-min_extrude_temp: 170
-max_extrude_only_distance: 780.0
-max_extrude_cross_section: 0.8
-pressure_advance: 0.0   # See tuning pressure advance doc
-pressure_advance_smooth_time: 0.040
-
-[tmc2209 extruder]
-uart_pin: PC11
-tx_pin: PC10
-uart_address: 3
-interpolate: True
-run_current: 0.3	# for LDO 36STH17-1004AHG 
-hold_current: 0.2	# for LDO 36STH17-1004AHG
-#run_current: 0.5	# for OMC 14HR07-1004VRN rated at 1A
-#hold_current: 0.3	# for OMC 14HR07-1004VRN rated at 1A
-sense_resistor: 0.110
-stealthchop_threshold: 0
-
-
-[heater_bed]
-heater_pin: PC9
-sensor_type: NTC 100K beta 3950 # For Keenovo, verify yours
-sensor_pin: PC3
-smooth_time: 3.0
-#max_power: 0.6         # Only need this for 100w pads
-min_temp: 0
-max_temp: 120
-control: pid            # Do PID calibration
-pid_kp: 68.453
-pid_ki: 2.749
-pid_kd: 426.122
-
+#####################################################################
+# Obtain definition by "ls -l /dev/serial/by-id/"
+#####################################################################
+serial: /dev/serial/by-id/usb-Klipper_stm32f103xe_REPLACE_WITH_YOUR_VALUE
 
 [printer]
 kinematics: corexy
@@ -152,6 +34,154 @@ max_z_velocity: 15
 max_z_accel: 45
 square_corner_velocity: 6.0
 
+#####################################################################
+#      X/Y Stepper Settings
+#####################################################################
+
+[stepper_x]
+step_pin: PB13
+dir_pin: PB12								# Add ! if moving opposite direction
+enable_pin: !PB14
+rotation_distance: 40
+microsteps: 16
+full_steps_per_rotation: 200				#set to 400 for 0.9 degree stepper
+endstop_pin: PC0 
+position_endstop: 120
+position_max: 120
+homing_speed: 50							# Increase after initial setup, Max 100
+homing_retract_dist: 5
+homing_positive_dir: true
+
+[tmc2209 stepper_x]
+uart_pin: PC11
+tx_pin: PC10
+uart_address: 0
+interpolate: True
+## LDO Motor
+run_current: 0.5
+hold_current: 0.25
+sense_resistor: 0.110
+stealthchop_threshold: 0					# Set to 9999 to turn off stealthchop
+
+[stepper_y]
+step_pin: PB10
+dir_pin: PB2								# Add ! if moving opposite direction
+enable_pin: !PB11
+rotation_distance: 40
+microsteps: 16
+full_steps_per_rotation: 200				#set to 400 for 0.9 degree stepper
+endstop_pin: PC1
+position_endstop: 120
+position_max: 120
+homing_speed: 50							# Increase after initial setup, Max 100
+homing_retract_dist: 5
+homing_positive_dir: true
+
+[tmc2209 stepper_y]
+uart_pin: PC11
+tx_pin: PC10
+uart_address: 2
+interpolate: True
+run_current: 0.5
+hold_current: 0.25
+sense_resistor: 0.110
+stealthchop_threshold: 0					# Set to 9999 to turn on stealthchop
+
+#####################################################################
+#   Z Stepper Settings
+#####################################################################
+
+[stepper_z]
+step_pin: PB0
+dir_pin: !PC5								# Remove ! if moving opposite direction
+enable_pin: !PB1
+rotation_distance: 8						# For T8x8 integrated lead screw
+microsteps: 16
+endstop_pin: PC2
+position_endstop: -0.10
+position_max: 120
+position_min: -1.5
+homing_speed: 10
+second_homing_speed: 3.0
+homing_retract_dist: 3.0
+
+[tmc2209 stepper_z]
+uart_pin: PC11
+tx_pin: PC10
+uart_address: 1
+interpolate: True
+## For OMC (StepperOnline) 17LS13-0404E-200G 0.4A 
+#run_current: 0.2
+#hold_current: 0.15
+## For LDO-42STH25-1004CL200E 1.0A
+run_current: 0.37
+hold_current: 0.35
+sense_resistor: 0.110
+stealthchop_threshold: 0					# Set to 9999 to turn on stealthchop
+
+#####################################################################
+#   Extruder
+#####################################################################
+
+[extruder]
+step_pin: PB3
+dir_pin: PB4								# Add ! if moving opposite direction
+enable_pin: !PD2
+full_steps_per_rotation: 200				# Set to 200 for LDO 1.8° motor, and set to 400 for OMC 0.9° motor
+rotation_distance: 22.23					# See calibrating rotation_distance on extruders doc
+gear_ratio: 50:10							# For Mini Afterburner
+microsteps: 16
+nozzle_diameter: 0.400
+filament_diameter: 1.750
+heater_pin: PC8
+sensor_type: NTC 100K MGB18-104F39050L32	# Adjust for your hotend thermistor (see options below)
+sensor_pin: PA0
+control: pid           						# Do PID calibration
+pid_Kp: 28.182
+pid_Ki: 1.978
+pid_Kd: 100.397
+min_temp: 0
+max_temp: 270
+min_extrude_temp: 190
+max_extrude_only_distance: 150
+max_extrude_cross_section: 0.8
+pressure_advance: 0.0						# See tuning pressure advance doc
+pressure_advance_smooth_time: 0.040
+
+[tmc2209 extruder]
+uart_pin: PC11
+tx_pin: PC10
+uart_address: 3
+interpolate: True
+## For OMC (StepperOnline) 14HR07-1004VRN 1A
+#run_current: 0.5	# for OMC 14HR07-1004VRN rated at 1A
+#hold_current: 0.3	# for OMC 14HR07-1004VRN rated at 1A
+## For LDO LDO 36STH17-1004AHG 1A
+run_current: 0.3	# for LDO 36STH17-1004AHG 
+hold_current: 0.2	# for LDO 36STH17-1004AHG
+sense_resistor: 0.110
+stealthchop_threshold: 0					# Do not use stealthchop on the extruder
+
+#####################################################################
+#   Bed Heater
+#####################################################################
+
+[heater_bed]
+heater_pin: PC9
+sensor_type: NTC 100K MGB18-104F39050L32	# For Keenovo, verify yours
+sensor_pin: PC3
+smooth_time: 3.0
+#max_power: 0.6								# Only needed for 100w pads
+min_temp: 0
+max_temp: 120
+control: pid								# Do PID calibration
+pid_kp: 68.453
+pid_ki: 2.749
+pid_kd: 426.122
+
+#####################################################################
+#	Fan Control
+#####################################################################
 
 [heater_fan hotend_fan]
 pin: PC7
@@ -159,32 +189,28 @@ max_power: 1.0
 kick_start_time: 0.5
 heater: extruder
 heater_temp: 50.0
-#fan_speed: 1.0         # You can't PWM the delta fan unless using blue wire
-
+#fan_speed: 1.0								# You can't PWM the delta fan unless using blue wire
 
 [fan]
 pin: PC6
 max_power: 1.0
-kick_start_time: 0.5
-#depending on your fan, you may need to increase or reduce this value
-#if your fan will not start
+kick_start_time: 0.5						# Depending on your fan, you may need to increase or reduce this value if your fan will not start
 off_below: 0.13
 cycle_time: 0.010
 
+#####################################################################
+#	Homing and Gantry Adjustment Routines
+#####################################################################
 
 [idle_timeout]
 timeout: 1800
-
 
 [safe_z_home]
 home_xy_position: 120,120
 speed: 50.0
 z_hop: 5
 
-
-# Tool to help adjust bed leveling screws. One may define a
-# [bed_screws] config section to enable a BED_SCREWS_ADJUST g-code
-# command.
+## To be used with BED_SCREWS_ADJUST
 [bed_screws]
 screw1: 60,5
 screw1_name: front screw
@@ -193,6 +219,9 @@ screw2_name: back left
 screw3: 115,115
 screw3_name: back right
 
+#####################################################################
+#	Macros
+#####################################################################
 
 [gcode_macro PRINT_START]
 #   Use PRINT_START for the slicer starting script - please customize for your slicer of choice
@@ -253,12 +282,12 @@ gcode:
    G1 E-40 F1800                  ; retract some, but not too much or it will jam
    M82                            ; set extruder to absolute
 
-# Sensor Types
-#   "EPCOS 100K B57560G104F"
-#   "ATC Semitec 104GT-2"
-#   "NTC 100K beta 3950" (Keenovo Heater Pad)
-#   "Honeywell 100K 135-104LAG-J01"
-#   "NTC 100K MGB18-104F39050L32"
-#   "AD595"
-#   "PT100 INA826"
-
+## 	Common Temperature Sensors
+##   "EPCOS 100K B57560G104F"
+##   "ATC Semitec 104GT-2"
+##   "NTC 100K beta 3950"
+##   "Honeywell 100K 135-104LAG-J01"
+##   "NTC 100K MGB18-104F39050L32" (Keenovo Heater Pad)
+##   "AD595"
+##   "PT100 INA826"
+##   "PT1000"

--- a/Firmware/printer.cfg
+++ b/Firmware/printer.cfg
@@ -13,7 +13,7 @@
 
 ## *** THINGS TO CHANGE/CHECK: ***
 ## MCU path                                                                     [mcu] section
-## Z and Extruder motor currents                                                [tmc2209 stepper_*] sections. Uncomment the motor you have
+## Z and Extruder motor currents                                                [tmc2209 stepper_*] sections. Uncomment the stepper motor you have
 ## Full steps per rotation for Extruder                                         [extruder] section
 ## Thermistor types                                                             [extruder] and [heater_bed] sections - See 'sensor types' list at end of file
 ## Extruder motor currents                                                      [extruder] section
@@ -136,7 +136,7 @@ microsteps: 16
 nozzle_diameter: 0.400
 filament_diameter: 1.750
 heater_pin: PC8
-sensor_type: EPCOS 100K B57560G104F                                 # Adjust for your hotend thermistor (see options at the bottom)
+sensor_type: EPCOS 100K B57560G104F                                 # Adjust for your hotend thermistor. See 'sensor types' list at end of file
 sensor_pin: PA0
 control: pid                                                        # Do PID calibration after initial checks
 pid_Kp: 28.182

--- a/Firmware/printer.cfg
+++ b/Firmware/printer.cfg
@@ -41,7 +41,7 @@ square_corner_velocity: 6.0
 
 [stepper_x]
 step_pin: PB13
-## Refer to https://docs.vorondesign.com/build/startup/images/V0-motor-configuration-guide.png
+## Refer to https://docs.vorondesign.com/build/startup/#v0
 dir_pin: PB12                                                       # Invert by adding ! if motors are correct
 enable_pin: !PB14
 rotation_distance: 40
@@ -66,7 +66,7 @@ stealthchop_threshold: 0                                            # Set to 999
 
 [stepper_y]
 step_pin: PB10
-## Refer to https://docs.vorondesign.com/build/startup/images/V0-motor-configuration-guide.png
+## Refer to https://docs.vorondesign.com/build/startup/#v0
 dir_pin: PB2                                                        # Invert by adding ! if motors are correct
 enable_pin: !PB11
 rotation_distance: 40

--- a/Firmware/printer.cfg
+++ b/Firmware/printer.cfg
@@ -12,13 +12,13 @@
 ## Voron Design VORON 0.1 SKR Mini E3 V2 config
 
 ## *** THINGS TO CHANGE/CHECK: ***
-## MCU path										[mcu] section
-## Z Motor currents								[tmc2209 stepper_z] section
-## Thermistor types								[extruder] and [heater_bed] sections - See 'sensor types' list at end of file
-## Extruder motor currents						[extruder] section
-## PID tune										[extruder] and [heater_bed] sections
-## Fine tune E steps							[extruder] section
-## For more info								check https://docs.vorondesign.com/build/startup/#v0
+## MCU path                                                                     [mcu] section
+## Z Motor currents                                                             [tmc2209 stepper_z] section
+## Thermistor types                                                             [extruder] and [heater_bed] sections - See 'sensor types' list at end of file
+## Extruder motor currents                                                      [extruder] section
+## PID tune                                                                     [extruder] and [heater_bed] sections
+## Fine tune E steps                                                            [extruder] section
+## For more info                                                                check https://docs.vorondesign.com/build/startup/#v0
 
 [mcu]
 #####################################################################
@@ -40,15 +40,15 @@ square_corner_velocity: 6.0
 
 [stepper_x]
 step_pin: PB13
-dir_pin: PB12								# Add ! if moving opposite direction
+dir_pin: PB12                                                                   # Add ! if moving opposite direction
 enable_pin: !PB14
 rotation_distance: 40
 microsteps: 16
-full_steps_per_rotation: 200				#set to 400 for 0.9 degree stepper
+full_steps_per_rotation: 200                                                    # Set to 400 for 0.9 degree stepper
 endstop_pin: PC0 
 position_endstop: 120
 position_max: 120
-homing_speed: 50							# Increase after initial setup, Max 100
+homing_speed: 50                                                                # Increase after initial setup, Max 100
 homing_retract_dist: 5
 homing_positive_dir: true
 
@@ -61,19 +61,19 @@ interpolate: True
 run_current: 0.5
 hold_current: 0.25
 sense_resistor: 0.110
-stealthchop_threshold: 0					# Set to 9999 to turn off stealthchop
+stealthchop_threshold: 0                                                        # Set to 9999 to turn off stealthchop
 
 [stepper_y]
 step_pin: PB10
-dir_pin: PB2								# Add ! if moving opposite direction
+dir_pin: PB2                                                                    # Add ! if moving opposite direction
 enable_pin: !PB11
 rotation_distance: 40
 microsteps: 16
-full_steps_per_rotation: 200				#set to 400 for 0.9 degree stepper
+full_steps_per_rotation: 200                                                    # Set to 400 for 0.9 degree stepper
 endstop_pin: PC1
 position_endstop: 120
 position_max: 120
-homing_speed: 50							# Increase after initial setup, Max 100
+homing_speed: 50                                                                # Increase after initial setup, Max 100
 homing_retract_dist: 5
 homing_positive_dir: true
 
@@ -85,7 +85,7 @@ interpolate: True
 run_current: 0.5
 hold_current: 0.25
 sense_resistor: 0.110
-stealthchop_threshold: 0					# Set to 9999 to turn on stealthchop
+stealthchop_threshold: 0                                                        # Set to 9999 to turn on stealthchop
 
 #####################################################################
 #   Z Stepper Settings
@@ -93,9 +93,9 @@ stealthchop_threshold: 0					# Set to 9999 to turn on stealthchop
 
 [stepper_z]
 step_pin: PB0
-dir_pin: !PC5								# Remove ! if moving opposite direction
+dir_pin: !PC5                                                                   # Remove ! if moving opposite direction
 enable_pin: !PB1
-rotation_distance: 8						# For T8x8 integrated lead screw
+rotation_distance: 8                                                            # For T8x8 integrated lead screw
 microsteps: 16
 endstop_pin: PC2
 position_endstop: -0.10
@@ -117,7 +117,7 @@ interpolate: True
 run_current: 0.37
 hold_current: 0.35
 sense_resistor: 0.110
-stealthchop_threshold: 0					# Set to 9999 to turn on stealthchop
+stealthchop_threshold: 0                                                        # Set to 9999 to turn on stealthchop
 
 #####################################################################
 #   Extruder
@@ -125,18 +125,18 @@ stealthchop_threshold: 0					# Set to 9999 to turn on stealthchop
 
 [extruder]
 step_pin: PB3
-dir_pin: PB4								# Add ! if moving opposite direction
+dir_pin: PB4                                                                    # Add ! if moving opposite direction
 enable_pin: !PD2
-full_steps_per_rotation: 200				# Set to 200 for LDO 1.8° motor, and set to 400 for OMC 0.9° motor
-rotation_distance: 22.23					# See calibrating rotation_distance on extruders doc
-gear_ratio: 50:10							# For Mini Afterburner
+full_steps_per_rotation: 200                                                    # Set to 200 for LDO 1.8° motor, and set to 400 for OMC 0.9° motor
+rotation_distance: 22.23                                                        # See calibrating rotation_distance on extruders doc
+gear_ratio: 50:10                                                               # For Mini Afterburner
 microsteps: 16
 nozzle_diameter: 0.400
 filament_diameter: 1.750
 heater_pin: PC8
-sensor_type: NTC 100K MGB18-104F39050L32	# Adjust for your hotend thermistor (see options below)
+sensor_type: NTC 100K MGB18-104F39050L32                                       # Adjust for your hotend thermistor (see options below)
 sensor_pin: PA0
-control: pid           						# Do PID calibration
+control: pid                                                                   # Do PID calibration
 pid_Kp: 28.182
 pid_Ki: 1.978
 pid_Kd: 100.397
@@ -145,7 +145,7 @@ max_temp: 270
 min_extrude_temp: 190
 max_extrude_only_distance: 150
 max_extrude_cross_section: 0.8
-pressure_advance: 0.0						# See tuning pressure advance doc
+pressure_advance: 0.0                                                           # See tuning pressure advance doc
 pressure_advance_smooth_time: 0.040
 
 [tmc2209 extruder]
@@ -160,7 +160,7 @@ interpolate: True
 run_current: 0.3	# for LDO 36STH17-1004AHG 
 hold_current: 0.2	# for LDO 36STH17-1004AHG
 sense_resistor: 0.110
-stealthchop_threshold: 0					# Do not use stealthchop on the extruder
+stealthchop_threshold: 0                                                        # Do not use stealthchop on the extruder
 
 #####################################################################
 #   Bed Heater
@@ -168,13 +168,13 @@ stealthchop_threshold: 0					# Do not use stealthchop on the extruder
 
 [heater_bed]
 heater_pin: PC9
-sensor_type: NTC 100K MGB18-104F39050L32	# For Keenovo, verify yours
+sensor_type: NTC 100K MGB18-104F39050L32                                        # For Keenovo, verify yours
 sensor_pin: PC3
 smooth_time: 3.0
-#max_power: 0.6								# Only needed for 100w pads
+#max_power: 0.6                                                                 # Only needed for 100w pads
 min_temp: 0
 max_temp: 120
-control: pid								# Do PID calibration
+control: pid                                                                    # Do PID calibration
 pid_kp: 68.453
 pid_ki: 2.749
 pid_kd: 426.122
@@ -189,12 +189,12 @@ max_power: 1.0
 kick_start_time: 0.5
 heater: extruder
 heater_temp: 50.0
-#fan_speed: 1.0								# You can't PWM the delta fan unless using blue wire
+#fan_speed: 1.0	                                                                # You can't PWM the delta fan unless using blue wire
 
 [fan]
 pin: PC6
 max_power: 1.0
-kick_start_time: 0.5						# Depending on your fan, you may need to increase or reduce this value if your fan will not start
+kick_start_time: 0.5                                                            # Depending on your fan, you may need to increase or reduce this value if your fan will not start
 off_below: 0.13
 cycle_time: 0.010
 

--- a/Firmware/printer.cfg
+++ b/Firmware/printer.cfg
@@ -42,15 +42,15 @@ square_corner_velocity: 6.0
 [stepper_x]
 step_pin: PB13
 ## Refer to https://docs.vorondesign.com/build/startup/#v0
-dir_pin: PB12                                                       # Invert by adding ! if motors are correct
+dir_pin: PB12                                                       # Check motor direction in link above. If inverted, add a ! before PB12
 enable_pin: !PB14
 rotation_distance: 40
 microsteps: 16
-full_steps_per_rotation: 200                                        # Set to 400 for 0.9 degree stepper
+full_steps_per_rotation: 200                                        # Set to 400 for 0.9° degree stepper motor, 200 is for 1.8° stepper motors
 endstop_pin: PC0 
 position_endstop: 120
 position_max: 120
-homing_speed: 50                                                    # Increase after initial setup, Max 100
+homing_speed: 50                                                    # Can be increased after initial setup, Max 100
 homing_retract_dist: 5
 homing_positive_dir: true
 
@@ -67,15 +67,15 @@ stealthchop_threshold: 0                                            # Set to 999
 [stepper_y]
 step_pin: PB10
 ## Refer to https://docs.vorondesign.com/build/startup/#v0
-dir_pin: PB2                                                        # Invert by adding ! if motors are correct
+dir_pin: PB2                                                        # Check motor direction in link above. If inverted, add a ! before PB2
 enable_pin: !PB11
 rotation_distance: 40
 microsteps: 16
-full_steps_per_rotation: 200                                        # Set to 400 for 0.9 degree stepper
+full_steps_per_rotation: 200                                        # Set to 400 for 0.9° degree stepper motor, 200 is for 1.8° stepper motors
 endstop_pin: PC1
 position_endstop: 120
 position_max: 120
-homing_speed: 50                                                    # Increase after initial setup, Max 100
+homing_speed: 50                                                    # Can be increased after initial setup, Max 100
 homing_retract_dist: 5
 homing_positive_dir: true
 
@@ -95,7 +95,7 @@ stealthchop_threshold: 0                                            # Set to 999
 
 [stepper_z]
 step_pin: PB0
-dir_pin: !PC5                                                       # Remove ! if moving opposite direction
+dir_pin: !PC5                                                       # Remove the ! before PC5 if motor direction is inverted.
 enable_pin: !PB1
 rotation_distance: 8                                                # For T8x8 integrated lead screw
 microsteps: 16
@@ -129,16 +129,16 @@ stealthchop_threshold: 0                                            # Set to 999
 step_pin: PB3
 dir_pin: PB4                                                        # Add ! if moving opposite direction
 enable_pin: !PD2
-#full_steps_per_rotation: 200                                       # Set to 200 for LDO 1.8° motor, and set to 400 for OMC 0.9° motor
+#full_steps_per_rotation: 200                                       # Set to 200 for LDO 1.8° stepper motor, and set to 400 for OMC(StepperOnline) 0.9° stepper motor
 rotation_distance: 22.23                                            # See calibrating rotation_distance on extruders doc
 gear_ratio: 50:10                                                   # For Mini Afterburner
 microsteps: 16
 nozzle_diameter: 0.400
 filament_diameter: 1.750
 heater_pin: PC8
-sensor_type: EPCOS 100K B57560G104F                                 # Adjust for your hotend thermistor (see options below)
+sensor_type: EPCOS 100K B57560G104F                                 # Adjust for your hotend thermistor (see options at the bottom)
 sensor_pin: PA0
-control: pid                                                        # Do PID calibration
+control: pid                                                        # Do PID calibration after initial checks
 pid_Kp: 28.182
 pid_Ki: 1.978
 pid_Kd: 100.397
@@ -176,7 +176,7 @@ smooth_time: 3.0
 #max_power: 0.6                                                     # Only needed for 100w pads
 min_temp: 0
 max_temp: 120
-control: pid                                                        # Do PID calibration
+control: pid                                                        # Do PID calibration after initial checks
 pid_kp: 68.453
 pid_ki: 2.749
 pid_kd: 426.122
@@ -209,7 +209,7 @@ heater_temp: 50.0
 [fan]
 pin: PC6
 max_power: 1.0
-kick_start_time: 0.5                                                # Depending on your fan, you may need to increase or reduce this value if your fan will not start
+kick_start_time: 0.5                                                # Depending on your fan, you may need to increase this value if your fan will not start
 off_below: 0.13
 cycle_time: 0.010
 

--- a/Firmware/printer.cfg
+++ b/Firmware/printer.cfg
@@ -41,7 +41,8 @@ square_corner_velocity: 6.0
 
 [stepper_x]
 step_pin: PB13
-dir_pin: PB12                                                       # Add ! if moving opposite direction
+## Refer to https://docs.vorondesign.com/build/startup/images/V0-motor-configuration-guide.png
+dir_pin: PB12                                                       # Invert by adding ! if motors are correct
 enable_pin: !PB14
 rotation_distance: 40
 microsteps: 16
@@ -65,7 +66,8 @@ stealthchop_threshold: 0                                            # Set to 999
 
 [stepper_y]
 step_pin: PB10
-dir_pin: PB2                                                        # Add ! if moving opposite direction
+## Refer to https://docs.vorondesign.com/build/startup/images/V0-motor-configuration-guide.png
+dir_pin: PB2                                                        # Invert by adding ! if motors are correct
 enable_pin: !PB11
 rotation_distance: 40
 microsteps: 16

--- a/Firmware/printer.cfg
+++ b/Firmware/printer.cfg
@@ -13,7 +13,8 @@
 
 ## *** THINGS TO CHANGE/CHECK: ***
 ## MCU path                                                                     [mcu] section
-## Z Motor currents                                                             [tmc2209 stepper_z] section
+## Z and Extruder motor currents                                                [tmc2209 stepper_*] sections. Uncomment the motor you have
+## Full steps per rotation for Extruder                                         [extruder] section
 ## Thermistor types                                                             [extruder] and [heater_bed] sections - See 'sensor types' list at end of file
 ## Extruder motor currents                                                      [extruder] section
 ## PID tune                                                                     [extruder] and [heater_bed] sections
@@ -40,15 +41,15 @@ square_corner_velocity: 6.0
 
 [stepper_x]
 step_pin: PB13
-dir_pin: PB12                                                                   # Add ! if moving opposite direction
+dir_pin: PB12                                                       # Add ! if moving opposite direction
 enable_pin: !PB14
 rotation_distance: 40
 microsteps: 16
-full_steps_per_rotation: 200                                                    # Set to 400 for 0.9 degree stepper
+full_steps_per_rotation: 200                                        # Set to 400 for 0.9 degree stepper
 endstop_pin: PC0 
 position_endstop: 120
 position_max: 120
-homing_speed: 50                                                                # Increase after initial setup, Max 100
+homing_speed: 50                                                    # Increase after initial setup, Max 100
 homing_retract_dist: 5
 homing_positive_dir: true
 
@@ -57,23 +58,22 @@ uart_pin: PC11
 tx_pin: PC10
 uart_address: 0
 interpolate: True
-## LDO Motor
 run_current: 0.5
 hold_current: 0.25
 sense_resistor: 0.110
-stealthchop_threshold: 0                                                        # Set to 9999 to turn off stealthchop
+stealthchop_threshold: 0                                            # Set to 9999 to turn off stealthchop
 
 [stepper_y]
 step_pin: PB10
-dir_pin: PB2                                                                    # Add ! if moving opposite direction
+dir_pin: PB2                                                        # Add ! if moving opposite direction
 enable_pin: !PB11
 rotation_distance: 40
 microsteps: 16
-full_steps_per_rotation: 200                                                    # Set to 400 for 0.9 degree stepper
+full_steps_per_rotation: 200                                        # Set to 400 for 0.9 degree stepper
 endstop_pin: PC1
 position_endstop: 120
 position_max: 120
-homing_speed: 50                                                                # Increase after initial setup, Max 100
+homing_speed: 50                                                    # Increase after initial setup, Max 100
 homing_retract_dist: 5
 homing_positive_dir: true
 
@@ -85,7 +85,7 @@ interpolate: True
 run_current: 0.5
 hold_current: 0.25
 sense_resistor: 0.110
-stealthchop_threshold: 0                                                        # Set to 9999 to turn on stealthchop
+stealthchop_threshold: 0                                            # Set to 9999 to turn on stealthchop
 
 #####################################################################
 #   Z Stepper Settings
@@ -93,9 +93,9 @@ stealthchop_threshold: 0                                                        
 
 [stepper_z]
 step_pin: PB0
-dir_pin: !PC5                                                                   # Remove ! if moving opposite direction
+dir_pin: !PC5                                                       # Remove ! if moving opposite direction
 enable_pin: !PB1
-rotation_distance: 8                                                            # For T8x8 integrated lead screw
+rotation_distance: 8                                                # For T8x8 integrated lead screw
 microsteps: 16
 endstop_pin: PC2
 position_endstop: -0.10
@@ -114,10 +114,10 @@ interpolate: True
 #run_current: 0.2
 #hold_current: 0.15
 ## For LDO-42STH25-1004CL200E 1.0A
-run_current: 0.37
-hold_current: 0.35
+#run_current: 0.37
+#hold_current: 0.35
 sense_resistor: 0.110
-stealthchop_threshold: 0                                                        # Set to 9999 to turn on stealthchop
+stealthchop_threshold: 0                                            # Set to 9999 to turn on stealthchop
 
 #####################################################################
 #   Extruder
@@ -125,27 +125,27 @@ stealthchop_threshold: 0                                                        
 
 [extruder]
 step_pin: PB3
-dir_pin: PB4                                                                    # Add ! if moving opposite direction
+dir_pin: PB4                                                        # Add ! if moving opposite direction
 enable_pin: !PD2
-full_steps_per_rotation: 200                                                    # Set to 200 for LDO 1.8° motor, and set to 400 for OMC 0.9° motor
-rotation_distance: 22.23                                                        # See calibrating rotation_distance on extruders doc
-gear_ratio: 50:10                                                               # For Mini Afterburner
+#full_steps_per_rotation: 200                                       # Set to 200 for LDO 1.8° motor, and set to 400 for OMC 0.9° motor
+rotation_distance: 22.23                                            # See calibrating rotation_distance on extruders doc
+gear_ratio: 50:10                                                   # For Mini Afterburner
 microsteps: 16
 nozzle_diameter: 0.400
 filament_diameter: 1.750
 heater_pin: PC8
-sensor_type: NTC 100K MGB18-104F39050L32                                       # Adjust for your hotend thermistor (see options below)
+sensor_type: EPCOS 100K B57560G104F                                 # Adjust for your hotend thermistor (see options below)
 sensor_pin: PA0
-control: pid                                                                   # Do PID calibration
+control: pid                                                        # Do PID calibration
 pid_Kp: 28.182
 pid_Ki: 1.978
 pid_Kd: 100.397
 min_temp: 0
 max_temp: 270
-min_extrude_temp: 190
+min_extrude_temp: 170
 max_extrude_only_distance: 150
 max_extrude_cross_section: 0.8
-pressure_advance: 0.0                                                           # See tuning pressure advance doc
+pressure_advance: 0.0                                               # See tuning pressure advance doc
 pressure_advance_smooth_time: 0.040
 
 [tmc2209 extruder]
@@ -153,14 +153,14 @@ uart_pin: PC11
 tx_pin: PC10
 uart_address: 3
 interpolate: True
-## For OMC (StepperOnline) 14HR07-1004VRN 1A
+## For OMC (StepperOnline) 14HR07-1004VRN 1A 0.9°
 #run_current: 0.5	# for OMC 14HR07-1004VRN rated at 1A
 #hold_current: 0.3	# for OMC 14HR07-1004VRN rated at 1A
-## For LDO LDO 36STH17-1004AHG 1A
-run_current: 0.3	# for LDO 36STH17-1004AHG 
-hold_current: 0.2	# for LDO 36STH17-1004AHG
+## For LDO LDO 36STH17-1004AHG 1A 1.8°
+#run_current: 0.3	# for LDO 36STH17-1004AHG 
+#hold_current: 0.2	# for LDO 36STH17-1004AHG
 sense_resistor: 0.110
-stealthchop_threshold: 0                                                        # Do not use stealthchop on the extruder
+stealthchop_threshold: 0                                            # Do not use stealthchop on the extruder
 
 #####################################################################
 #   Bed Heater
@@ -168,16 +168,29 @@ stealthchop_threshold: 0                                                        
 
 [heater_bed]
 heater_pin: PC9
-sensor_type: NTC 100K MGB18-104F39050L32                                        # For Keenovo, verify yours
+sensor_type: NTC 100K MGB18-104F39050L32                            # For Keenovo, verify yours
 sensor_pin: PC3
 smooth_time: 3.0
-#max_power: 0.6                                                                 # Only needed for 100w pads
+#max_power: 0.6                                                     # Only needed for 100w pads
 min_temp: 0
 max_temp: 120
-control: pid                                                                    # Do PID calibration
+control: pid                                                        # Do PID calibration
 pid_kp: 68.453
 pid_ki: 2.749
 pid_kd: 426.122
+
+#####################################################################
+#	Thermistor definitions
+#####################################################################
+
+[thermistor Trianglelab NTC100K B3950]
+## values calibrated against a PT100 reference
+temperature1: 25.0
+resistance1: 103180.0
+temperature2: 150.0
+resistance2: 1366.2
+temperature3: 250.0
+resistance3: 168.6
 
 #####################################################################
 #	Fan Control
@@ -189,12 +202,12 @@ max_power: 1.0
 kick_start_time: 0.5
 heater: extruder
 heater_temp: 50.0
-#fan_speed: 1.0	                                                                # You can't PWM the delta fan unless using blue wire
+#fan_speed: 1.0	                                                    # You can't PWM the delta fan unless using blue wire
 
 [fan]
 pin: PC6
 max_power: 1.0
-kick_start_time: 0.5                                                            # Depending on your fan, you may need to increase or reduce this value if your fan will not start
+kick_start_time: 0.5                                                # Depending on your fan, you may need to increase or reduce this value if your fan will not start
 off_below: 0.13
 cycle_time: 0.010
 
@@ -282,7 +295,8 @@ gcode:
    G1 E-40 F1800                  ; retract some, but not too much or it will jam
    M82                            ; set extruder to absolute
 
-## 	Common Temperature Sensors
+##   Sensor Types
+##   "Trianglelab NTC100K B3950" (Beta 3950 used in LDO kits)
 ##   "EPCOS 100K B57560G104F"
 ##   "ATC Semitec 104GT-2"
 ##   "NTC 100K beta 3950"
@@ -291,3 +305,8 @@ gcode:
 ##   "AD595"
 ##   "PT100 INA826"
 ##   "PT1000"
+##   For more information: https://www.klipper3d.org/Config_Reference.html#temperature_sensor
+
+## Footnote about Beta 3950:
+## https://github.com/Klipper3d/klipper/issues/4054
+## https://github.com/Klipper3d/klipper/pull/4859

--- a/Firmware/printer.cfg
+++ b/Firmware/printer.cfg
@@ -62,7 +62,7 @@ interpolate: True
 run_current: 0.5
 hold_current: 0.25
 sense_resistor: 0.110
-stealthchop_threshold: 0                                            # Set to 9999 to turn off stealthchop
+stealthchop_threshold: 0                                            # Set to 999999 to turn stealthchop on, and 0 to use spreadcycle
 
 [stepper_y]
 step_pin: PB10
@@ -87,7 +87,7 @@ interpolate: True
 run_current: 0.5
 hold_current: 0.25
 sense_resistor: 0.110
-stealthchop_threshold: 0                                            # Set to 9999 to turn on stealthchop
+stealthchop_threshold: 0                                            # Set to 999999 to turn stealthchop on, and 0 to use spreadcycle
 
 #####################################################################
 #   Z Stepper Settings
@@ -119,7 +119,7 @@ interpolate: True
 #run_current: 0.37
 #hold_current: 0.35
 sense_resistor: 0.110
-stealthchop_threshold: 0                                            # Set to 9999 to turn on stealthchop
+stealthchop_threshold: 0                                            # Set to 999999 to turn stealthchop on, and 0 to use spreadcycle
 
 #####################################################################
 #   Extruder
@@ -162,7 +162,7 @@ interpolate: True
 #run_current: 0.3	# for LDO 36STH17-1004AHG 
 #hold_current: 0.2	# for LDO 36STH17-1004AHG
 sense_resistor: 0.110
-stealthchop_threshold: 0                                            # Do not use stealthchop on the extruder
+stealthchop_threshold: 0                                            # Set to 0 for spreadcycle, avoid using stealthchop on extruder
 
 #####################################################################
 #   Bed Heater


### PR DESCRIPTION
Update printer.cfg and make it default for LDO kits.
I used Voron 2.4's spider conf as template and tried to keep it as close to the values that were already in the conf, while making it a little easier to see what to change and so on.