### PR TITLE
Update suggestive thermistor comments

### DIFF
--- a/Firmware/printer.cfg
+++ b/Firmware/printer.cfg
@@ -182,19 +182,6 @@ pid_ki: 2.749
 pid_kd: 426.122
 
 #####################################################################
-#	Thermistor definitions
-#####################################################################
-
-[thermistor Trianglelab NTC100K B3950]
-## values calibrated against a PT100 reference
-temperature1: 25.0
-resistance1: 103180.0
-temperature2: 150.0
-resistance2: 1366.2
-temperature3: 250.0
-resistance3: 168.6
-
-#####################################################################
 #	Fan Control
 #####################################################################
 
@@ -298,12 +285,11 @@ gcode:
    M82                            ; set extruder to absolute
 
 ##   Sensor Types
-##   "Trianglelab NTC100K B3950" (Beta 3950 used in LDO kits)
 ##   "EPCOS 100K B57560G104F"
 ##   "ATC Semitec 104GT-2"
 ##   "NTC 100K beta 3950"
 ##   "Honeywell 100K 135-104LAG-J01"
-##   "NTC 100K MGB18-104F39050L32" (Keenovo Heater Pad)
+##   "NTC 100K MGB18-104F39050L32" (Keenovo Heater Pad and the Beta 3950 provided by LDO)
 ##   "AD595"
 ##   "PT100 INA826"
 ##   "PT1000"


### PR DESCRIPTION
Seems I was wrong about the Beta 3950 definitions and that the keenovo spreadsheet is a closer fit.
-Remove thermistor definition, can still be found via footnote/links
-Update suggestion in sensor types list
Thanks to user Armin#3486 for reporting and comparing thermistor to a Semitec 104GT-2.