### PR TITLE
Remove suggestive comment

### DIFF
--- a/Firmware/printer.cfg
+++ b/Firmware/printer.cfg
@@ -298,7 +298,7 @@ gcode:
    M82                            ; set extruder to absolute
 
 ##   Sensor Types
-##   "Trianglelab NTC100K B3950" (Beta 3950 used in LDO kits)
+##   "Trianglelab NTC100K B3950"
 ##   "EPCOS 100K B57560G104F"
 ##   "ATC Semitec 104GT-2"
 ##   "NTC 100K beta 3950"


### PR DESCRIPTION
Let's just remove this comment and leave all options open. The trianglelab definition seem to run too hot for some, so not pointing anywhere leave things more open to interpretation instead of pointing at things. In one user's case the Keenovo definition was closer to expectations. So i think it makes sense to just leave it open and see where things go from there.