### PR TITLE
Update sensor types

### DIFF
--- a/Firmware/printer.cfg
+++ b/Firmware/printer.cfg
@@ -301,7 +301,7 @@ gcode:
 ##   "Trianglelab NTC100K B3950" (Beta 3950 used in LDO kits)
 ##   "EPCOS 100K B57560G104F"
 ##   "ATC Semitec 104GT-2"
-##   "NTC 100K beta 3950"
+##   "Generic 3950"
 ##   "Honeywell 100K 135-104LAG-J01"
 ##   "NTC 100K MGB18-104F39050L32" (Keenovo Heater Pad)
 ##   "AD595"


### PR DESCRIPTION
Renamed "NTC 100K beta 3950" to "Generic 3950". This was recently updated in klipper.