### PR TITLE
Enhance E3 mini V3 config

### DIFF
--- a/Firmware/skr-mini-E3-v3.0.cfg
+++ b/Firmware/skr-mini-E3-v3.0.cfg
@@ -118,6 +118,19 @@ sense_resistor: 0.110
 stealthchop_threshold: 0                                            # Set to 999999 to turn stealthchop on, and 0 to use spreadcycle
 
 #####################################################################
+#	Thermistor definitions
+#####################################################################
+
+[thermistor Trianglelab NTC100K B3950]
+## values calibrated against a PT100 reference
+temperature1: 25.0
+resistance1: 103180.0
+temperature2: 150.0
+resistance2: 1366.2
+temperature3: 250.0
+resistance3: 168.6
+
+#####################################################################
 #   Extruder
 #####################################################################
 
@@ -132,7 +145,9 @@ microsteps: 32
 nozzle_diameter: 0.400
 filament_diameter: 1.750
 heater_pin: PC8
-sensor_type: EPCOS 100K B57560G104F                                 # Adjust for your hotend thermistor. See 'sensor types' list at end of file
+##  Validate the following thermistor type to make sure it is correct
+##  See https://www.klipper3d.org/Config_Reference.html#common-thermistors for additional options
+#sensor_type: Trianglelab NTC100K B3950                             # Adjust for your hotend thermistor.
 sensor_pin: PA0
 control: pid                                                        # Do PID calibration after initial checks
 pid_Kp: 28.182
@@ -164,7 +179,9 @@ stealthchop_threshold: 0                                            # Set to 0 f
 
 [heater_bed]
 heater_pin: PC9
-sensor_type: NTC 100K MGB18-104F39050L32                            # For Keenovo, verify yours
+##  Validate the following thermistor type to make sure it is correct
+##  See https://www.klipper3d.org/Config_Reference.html#common-thermistors for additional options
+#sensor_type: NTC 100K MGB18-104F39050L32                           # For Keenovo, verify yours
 sensor_pin: PC4
 smooth_time: 3.0
 #max_power: 0.6                                                     # Only needed for 100w pads
@@ -176,23 +193,11 @@ pid_ki: 2.749
 pid_kd: 426.122
 
 #####################################################################
-#	Thermistor definitions
-#####################################################################
-
-[thermistor Trianglelab NTC100K B3950]
-## values calibrated against a PT100 reference
-temperature1: 25.0
-resistance1: 103180.0
-temperature2: 150.0
-resistance2: 1366.2
-temperature3: 250.0
-resistance3: 168.6
-
-#####################################################################
 #	Fan Control
 #####################################################################
 
 [heater_fan hotend_fan]
+# FAN1
 pin: PC7
 max_power: 1.0
 kick_start_time: 0.5
@@ -201,11 +206,20 @@ heater_temp: 50.0
 #fan_speed: 1.0	                                                    # You can't PWM the delta fan unless using blue wire
 
 [fan]
+# FAN0
 pin: PC6
 max_power: 1.0
 kick_start_time: 0.5                                                # Depending on your fan, you may need to increase this value if your fan will not start
 off_below: 0.13
 cycle_time: 0.010
+
+#[fan_generic fan2]
+## FAN2
+#pin: PB15
+#max_power: 1.0
+#kick_start_time: 0.5                                                # Depending on your fan, you may need to increase this value if your fan will not start
+#off_below: 0.13
+#cycle_time: 0.010
 
 #####################################################################
 #	Homing and Gantry Adjustment Routines
@@ -290,19 +304,3 @@ gcode:
    G1 E10 F300                    ; extrude a little to soften tip
    G1 E-40 F1800                  ; retract some, but not too much or it will jam
    M82                            ; set extruder to absolute
-
-##   Sensor Types
-##   "Trianglelab NTC100K B3950" (Beta 3950 used in LDO kits)
-##   "EPCOS 100K B57560G104F"
-##   "ATC Semitec 104GT-2"
-##   "Generic 3950"
-##   "Honeywell 100K 135-104LAG-J01"
-##   "NTC 100K MGB18-104F39050L32" (Keenovo Heater Pad)
-##   "AD595"
-##   "PT100 INA826"
-##   "PT1000"
-##   For more information: https://www.klipper3d.org/Config_Reference.html#temperature_sensor
-
-## Footnote about Beta 3950:
-## https://github.com/Klipper3d/klipper/issues/4054
-## https://github.com/Klipper3d/klipper/pull/4859


### PR DESCRIPTION
- Link to the Klipper thermistor page instead of hardcoding a list that might be outdated as comments
- Comment out `sensor_type` lines to force people to pick
- Add FAN2 config