### PR TITLE
Fix skr mini E3 V2.0 config (thermistor)

### DIFF
--- a/Firmware/skr-mini-E3-v2.0.cfg
+++ b/Firmware/skr-mini-E3-v2.0.cfg
@@ -118,6 +118,19 @@ sense_resistor: 0.110
 stealthchop_threshold: 0                                            # Set to 999999 to turn stealthchop on, and 0 to use spreadcycle
 
 #####################################################################
+#	Thermistor definitions
+#####################################################################
+
+[thermistor Trianglelab NTC100K B3950]
+## values calibrated against a PT100 reference
+temperature1: 25.0
+resistance1: 103180.0
+temperature2: 150.0
+resistance2: 1366.2
+temperature3: 250.0
+resistance3: 168.6
+
+#####################################################################
 #   Extruder
 #####################################################################
 
@@ -174,19 +187,6 @@ control: pid                                                        # Do PID cal
 pid_kp: 68.453
 pid_ki: 2.749
 pid_kd: 426.122
-
-#####################################################################
-#	Thermistor definitions
-#####################################################################
-
-[thermistor Trianglelab NTC100K B3950]
-## values calibrated against a PT100 reference
-temperature1: 25.0
-resistance1: 103180.0
-temperature2: 150.0
-resistance2: 1366.2
-temperature3: 250.0
-resistance3: 168.6
 
 #####################################################################
 #	Fan Control


### PR DESCRIPTION
move the `[thermistor]` block above of the `[extruder]` block