### PR TITLE
Add G90 to PRINT_START macro

### DIFF
--- a/Firmware/skr-mini-E3-v2.0.cfg
+++ b/Firmware/skr-mini-E3-v2.0.cfg
@@ -236,6 +236,7 @@ screw3_name: back right
 #   Use PRINT_START for the slicer starting script - please customize for your slicer of choice
 gcode:
     G28                            ; home all axes
+    G90                            ; absolute positioning    
     G1 Z20 F3000                   ; move nozzle away from bed
    
 [gcode_macro PRINT_END]

--- a/Firmware/skr-mini-E3-v3.0.cfg
+++ b/Firmware/skr-mini-E3-v3.0.cfg
@@ -234,6 +234,7 @@ screw3_name: back right
 #   Use PRINT_START for the slicer starting script - please customize for your slicer of choice
 gcode:
     G28                            ; home all axes
+    G90                            ; absolute positioning    
     G1 Z20 F3000                   ; move nozzle away from bed
    
 [gcode_macro PRINT_END]

--- a/Firmware/skr-pico-v1.0.cfg
+++ b/Firmware/skr-pico-v1.0.cfg
@@ -234,6 +234,7 @@ screw3_name: back right
 #   Use PRINT_START for the slicer starting script - please customize for your slicer of choice
 gcode:
     G28                            ; home all axes
+    G90                            ; absolute positioning    
     G1 Z20 F3000                   ; move nozzle away from bed
    
 [gcode_macro PRINT_END]


### PR DESCRIPTION
Added G90 to PRINT_START macro to prevent errors, when printer is in relative mode.