### PR TITLE
Remove default sensor_types, convert tabs to spaces

### DIFF
--- a/Firmware/skr-mini-E3-v2.0.cfg
+++ b/Firmware/skr-mini-E3-v2.0.cfg
@@ -281,7 +281,3 @@ gcode:
    G1 E10 F300                    ; extrude a little to soften tip
    G1 E-40 F1800                  ; retract some, but not too much or it will jam
    M82                            ; set extruder to absolute
-
-## Footnote about Beta 3950:
-## https://github.com/Klipper3d/klipper/issues/4054
-## https://github.com/Klipper3d/klipper/pull/4859

--- a/Firmware/skr-mini-E3-v2.0.cfg
+++ b/Firmware/skr-mini-E3-v2.0.cfg
@@ -15,7 +15,7 @@
 ## MCU path                                                                     [mcu] section
 ## Z and Extruder motor currents                                                [tmc2209 stepper_*] sections. Uncomment the stepper motor you have
 ## Full steps per rotation for Extruder                                         [extruder] section
-## Thermistor types                                                             [extruder] and [heater_bed] sections - See 'sensor types' list at end of file
+## Thermistor types                                                             [extruder] and [heater_bed] sections - See https://www.klipper3d.org/Config_Reference.html#common-thermistors for common thermistor types
 ## Extruder motor currents                                                      [extruder] section
 ## PID tune                                                                     [extruder] and [heater_bed] sections
 ## Fine tune E steps                                                            [extruder] section
@@ -118,19 +118,6 @@ sense_resistor: 0.110
 stealthchop_threshold: 0                                            # Set to 999999 to turn stealthchop on, and 0 to use spreadcycle
 
 #####################################################################
-#	Thermistor definitions
-#####################################################################
-
-[thermistor Trianglelab NTC100K B3950]
-## values calibrated against a PT100 reference
-temperature1: 25.0
-resistance1: 103180.0
-temperature2: 150.0
-resistance2: 1366.2
-temperature3: 250.0
-resistance3: 168.6
-
-#####################################################################
 #   Extruder
 #####################################################################
 
@@ -145,7 +132,9 @@ microsteps: 32
 nozzle_diameter: 0.400
 filament_diameter: 1.750
 heater_pin: PC8
-sensor_type: EPCOS 100K B57560G104F                                 # Adjust for your hotend thermistor. See 'sensor types' list at end of file
+## Check what thermistor type you have. See https://www.klipper3d.org/Config_Reference.html#common-thermistors for common thermistor types.
+## Use "Generic 3950" for NTC 100k 3950 thermistors
+sensor_type:
 sensor_pin: PA0
 control: pid                                                        # Do PID calibration after initial checks
 pid_Kp: 28.182
@@ -177,7 +166,9 @@ stealthchop_threshold: 0                                            # Set to 0 f
 
 [heater_bed]
 heater_pin: PC9
-sensor_type: NTC 100K MGB18-104F39050L32                            # For Keenovo, verify yours
+## Check what thermistor type you have. See https://www.klipper3d.org/Config_Reference.html#common-thermistors for common thermistor types.
+## Use "Generic 3950" for Keenovo heaters
+sensor_type:
 sensor_pin: PC3
 smooth_time: 3.0
 #max_power: 0.6                                                     # Only needed for 100w pads
@@ -290,18 +281,6 @@ gcode:
    G1 E10 F300                    ; extrude a little to soften tip
    G1 E-40 F1800                  ; retract some, but not too much or it will jam
    M82                            ; set extruder to absolute
-
-##   Sensor Types
-##   "Trianglelab NTC100K B3950" (Beta 3950 used in LDO kits)
-##   "EPCOS 100K B57560G104F"
-##   "ATC Semitec 104GT-2"
-##   "Generic 3950"
-##   "Honeywell 100K 135-104LAG-J01"
-##   "NTC 100K MGB18-104F39050L32" (Keenovo Heater Pad)
-##   "AD595"
-##   "PT100 INA826"
-##   "PT1000"
-##   For more information: https://www.klipper3d.org/Config_Reference.html#temperature_sensor
 
 ## Footnote about Beta 3950:
 ## https://github.com/Klipper3d/klipper/issues/4054

--- a/Firmware/skr-mini-E3-v2.0.cfg
+++ b/Firmware/skr-mini-E3-v2.0.cfg
@@ -134,7 +134,7 @@ filament_diameter: 1.750
 heater_pin: PC8
 ## Check what thermistor type you have. See https://www.klipper3d.org/Config_Reference.html#common-thermistors for common thermistor types.
 ## Use "Generic 3950" for NTC 100k 3950 thermistors
-sensor_type:
+#sensor_type:
 sensor_pin: PA0
 control: pid                                                        # Do PID calibration after initial checks
 pid_Kp: 28.182
@@ -154,9 +154,9 @@ tx_pin: PC10
 uart_address: 3
 interpolate: False
 ## For OMC (StepperOnline) 14HR07-1004VRN 1A 0.9°
-#run_current: 0.5	# for OMC 14HR07-1004VRN rated at 1A
+#run_current: 0.5   # for OMC 14HR07-1004VRN rated at 1A
 ## For LDO LDO 36STH17-1004AHG 1A 1.8° 
-#run_current: 0.3	# for LDO 36STH17-1004AHG
+#run_current: 0.3   # for LDO 36STH17-1004AHG
 sense_resistor: 0.110
 stealthchop_threshold: 0                                            # Set to 0 for spreadcycle, avoid using stealthchop on extruder
 
@@ -168,7 +168,7 @@ stealthchop_threshold: 0                                            # Set to 0 f
 heater_pin: PC9
 ## Check what thermistor type you have. See https://www.klipper3d.org/Config_Reference.html#common-thermistors for common thermistor types.
 ## Use "Generic 3950" for Keenovo heaters
-sensor_type:
+#sensor_type:
 sensor_pin: PC3
 smooth_time: 3.0
 #max_power: 0.6                                                     # Only needed for 100w pads
@@ -180,7 +180,7 @@ pid_ki: 2.749
 pid_kd: 426.122
 
 #####################################################################
-#	Fan Control
+#   Fan Control
 #####################################################################
 
 [heater_fan hotend_fan]
@@ -189,7 +189,7 @@ max_power: 1.0
 kick_start_time: 0.5
 heater: extruder
 heater_temp: 50.0
-#fan_speed: 1.0	                                                    # You can't PWM the delta fan unless using blue wire
+#fan_speed: 1.0                                                     # You can't PWM the delta fan unless using blue wire
 
 [fan]
 pin: PC6
@@ -199,7 +199,7 @@ off_below: 0.13
 cycle_time: 0.010
 
 #####################################################################
-#	Homing and Gantry Adjustment Routines
+#   Homing and Gantry Adjustment Routines
 #####################################################################
 
 [idle_timeout]
@@ -220,7 +220,7 @@ screw3: 115,115
 screw3_name: back right
 
 #####################################################################
-#	Macros
+#   Macros
 #####################################################################
 
 [gcode_macro PRINT_START]
@@ -267,7 +267,7 @@ gcode:
     M107                           ; turn off fan
     G90                            ; absolute positioning
     G0 X60 Y{max_y} F3600          ; park nozzle at rear
-	
+    
 [gcode_macro LOAD_FILAMENT]
 gcode:
    M83                            ; set extruder to relative

--- a/Firmware/skr-mini-E3-v3.0.cfg
+++ b/Firmware/skr-mini-E3-v3.0.cfg
@@ -132,7 +132,7 @@ filament_diameter: 1.750
 heater_pin: PC8
 ## Check what thermistor type you have. See https://www.klipper3d.org/Config_Reference.html#common-thermistors for common thermistor types.
 ## Use "Generic 3950" for NTC 100k 3950 thermistors
-sensor_type:
+#sensor_type:
 sensor_pin: PA0
 control: pid                                                        # Do PID calibration after initial checks
 pid_Kp: 28.182
@@ -152,9 +152,9 @@ tx_pin: PC10
 uart_address: 3
 interpolate: False
 ## For OMC (StepperOnline) 14HR07-1004VRN 1A 0.9°
-#run_current: 0.5	# for OMC 14HR07-1004VRN rated at 1A
+#run_current: 0.5   # for OMC 14HR07-1004VRN rated at 1A
 ## For LDO LDO 36STH17-1004AHG 1A 1.8° 
-#run_current: 0.3	# for LDO 36STH17-1004AHG
+#run_current: 0.3   # for LDO 36STH17-1004AHG
 sense_resistor: 0.110
 stealthchop_threshold: 0                                            # Set to 0 for spreadcycle, avoid using stealthchop on extruder
 
@@ -166,7 +166,7 @@ stealthchop_threshold: 0                                            # Set to 0 f
 heater_pin: PC9
 ## Check what thermistor type you have. See https://www.klipper3d.org/Config_Reference.html#common-thermistors for common thermistor types.
 ## Use "Generic 3950" for Keenovo heaters
-sensor_type:
+#sensor_type:
 sensor_pin: PC4
 smooth_time: 3.0
 #max_power: 0.6                                                     # Only needed for 100w pads
@@ -178,7 +178,7 @@ pid_ki: 2.749
 pid_kd: 426.122
 
 #####################################################################
-#	Fan Control
+#   Fan Control
 #####################################################################
 
 [heater_fan hotend_fan]
@@ -188,7 +188,7 @@ max_power: 1.0
 kick_start_time: 0.5
 heater: extruder
 heater_temp: 50.0
-#fan_speed: 1.0	                                                    # You can't PWM the delta fan unless using blue wire
+#fan_speed: 1.0                                                     # You can't PWM the delta fan unless using blue wire
 
 [fan]
 # FAN0
@@ -207,7 +207,7 @@ cycle_time: 0.010
 #cycle_time: 0.010
 
 #####################################################################
-#	Homing and Gantry Adjustment Routines
+#   Homing and Gantry Adjustment Routines
 #####################################################################
 
 [idle_timeout]
@@ -228,7 +228,7 @@ screw3: 115,115
 screw3_name: back right
 
 #####################################################################
-#	Macros
+#   Macros
 #####################################################################
 
 [gcode_macro PRINT_START]
@@ -275,7 +275,7 @@ gcode:
     M107                           ; turn off fan
     G90                            ; absolute positioning
     G0 X60 Y{max_y} F3600          ; park nozzle at rear
-	
+    
 [gcode_macro LOAD_FILAMENT]
 gcode:
    M83                            ; set extruder to relative

--- a/Firmware/skr-mini-E3-v3.0.cfg
+++ b/Firmware/skr-mini-E3-v3.0.cfg
@@ -13,7 +13,7 @@
 ## MCU path                                                                     [mcu] section
 ## Z and Extruder motor currents                                                [tmc2209 stepper_*] sections. Uncomment the stepper motor you have
 ## Full steps per rotation for Extruder                                         [extruder] section
-## Thermistor types                                                             [extruder] and [heater_bed] sections - See 'sensor types' list at end of file
+## Thermistor types                                                             [extruder] and [heater_bed] sections - See https://www.klipper3d.org/Config_Reference.html#common-thermistors for common thermistor types
 ## Extruder motor currents                                                      [extruder] section
 ## PID tune                                                                     [extruder] and [heater_bed] sections
 ## Fine tune E steps                                                            [extruder] section
@@ -116,19 +116,6 @@ sense_resistor: 0.110
 stealthchop_threshold: 0                                            # Set to 999999 to turn stealthchop on, and 0 to use spreadcycle
 
 #####################################################################
-#	Thermistor definitions
-#####################################################################
-
-[thermistor Trianglelab NTC100K B3950]
-## values calibrated against a PT100 reference
-temperature1: 25.0
-resistance1: 103180.0
-temperature2: 150.0
-resistance2: 1366.2
-temperature3: 250.0
-resistance3: 168.6
-
-#####################################################################
 #   Extruder
 #####################################################################
 
@@ -143,9 +130,9 @@ microsteps: 32
 nozzle_diameter: 0.400
 filament_diameter: 1.750
 heater_pin: PC8
-##  Validate the following thermistor type to make sure it is correct
-##  See https://www.klipper3d.org/Config_Reference.html#common-thermistors for additional options
-#sensor_type: Trianglelab NTC100K B3950                             # Adjust for your hotend thermistor.
+## Check what thermistor type you have. See https://www.klipper3d.org/Config_Reference.html#common-thermistors for common thermistor types.
+## Use "Generic 3950" for NTC 100k 3950 thermistors
+sensor_type:
 sensor_pin: PA0
 control: pid                                                        # Do PID calibration after initial checks
 pid_Kp: 28.182
@@ -177,9 +164,9 @@ stealthchop_threshold: 0                                            # Set to 0 f
 
 [heater_bed]
 heater_pin: PC9
-##  Validate the following thermistor type to make sure it is correct
-##  See https://www.klipper3d.org/Config_Reference.html#common-thermistors for additional options
-#sensor_type: NTC 100K MGB18-104F39050L32                           # For Keenovo, verify yours
+## Check what thermistor type you have. See https://www.klipper3d.org/Config_Reference.html#common-thermistors for common thermistor types.
+## Use "Generic 3950" for Keenovo heaters
+sensor_type:
 sensor_pin: PC4
 smooth_time: 3.0
 #max_power: 0.6                                                     # Only needed for 100w pads

--- a/Firmware/skr-pico-v1.0.cfg
+++ b/Firmware/skr-pico-v1.0.cfg
@@ -132,7 +132,7 @@ filament_diameter: 1.750
 heater_pin: gpio23
 ## Check what thermistor type you have. See https://www.klipper3d.org/Config_Reference.html#common-thermistors for common thermistor types.
 ## Use "Generic 3950" for NTC 100k 3950 thermistors
-sensor_type:
+#sensor_type:
 sensor_pin: gpio27
 control: pid                                                        # Do PID calibration after initial checks
 pid_Kp: 28.182
@@ -166,7 +166,7 @@ stealthchop_threshold: 0                                            # Set to 0 f
 heater_pin: gpio21
 ## Check what thermistor type you have. See https://www.klipper3d.org/Config_Reference.html#common-thermistors for common thermistor types.
 ## Use "Generic 3950" for Keenovo heaters
-sensor_type:
+#sensor_type:
 sensor_pin: gpio26
 smooth_time: 3.0
 #max_power: 0.6                                                     # Only needed for 100w pads

--- a/Firmware/skr-pico-v1.0.cfg
+++ b/Firmware/skr-pico-v1.0.cfg
@@ -12,7 +12,7 @@
 ## MCU path                                                                     [mcu] section
 ## Z and Extruder motor currents                                                [tmc2209 stepper_*] sections. Uncomment the stepper motor you have
 ## Full steps per rotation for Extruder                                         [extruder] section
-## Thermistor types                                                             [extruder] and [heater_bed] sections - See 'sensor types' list at end of file
+## Thermistor types                                                             [extruder] and [heater_bed] sections - See https://www.klipper3d.org/Config_Reference.html#common-thermistors for common thermistor types
 ## Extruder motor currents                                                      [extruder] section
 ## PID tune                                                                     [extruder] and [heater_bed] sections
 ## Fine tune E steps                                                            [extruder] section
@@ -116,19 +116,6 @@ sense_resistor: 0.110
 stealthchop_threshold: 0                                            # Set to 999999 to turn stealthchop on, and 0 to use spreadcycle
 
 #####################################################################
-# Thermistor definitions
-#####################################################################
-
-[thermistor Trianglelab NTC100K B3950]
-## values calibrated against a PT100 reference
-temperature1: 25.0
-resistance1: 103180.0
-temperature2: 150.0
-resistance2: 1366.2
-temperature3: 250.0
-resistance3: 168.6
-
-#####################################################################
 #   Extruder
 #####################################################################
 
@@ -143,7 +130,9 @@ microsteps: 32
 nozzle_diameter: 0.400
 filament_diameter: 1.750
 heater_pin: gpio23
-sensor_type: EPCOS 100K B57560G104F                                 # Adjust for your hotend thermistor. See 'sensor types' list at end of file
+## Check what thermistor type you have. See https://www.klipper3d.org/Config_Reference.html#common-thermistors for common thermistor types.
+## Use "Generic 3950" for NTC 100k 3950 thermistors
+sensor_type:
 sensor_pin: gpio27
 control: pid                                                        # Do PID calibration after initial checks
 pid_Kp: 28.182
@@ -175,7 +164,9 @@ stealthchop_threshold: 0                                            # Set to 0 f
 
 [heater_bed]
 heater_pin: gpio21
-sensor_type: NTC 100K MGB18-104F39050L32                            # For Keenovo, verify yours
+## Check what thermistor type you have. See https://www.klipper3d.org/Config_Reference.html#common-thermistors for common thermistor types.
+## Use "Generic 3950" for Keenovo heaters
+sensor_type:
 sensor_pin: gpio26
 smooth_time: 3.0
 #max_power: 0.6                                                     # Only needed for 100w pads
@@ -288,18 +279,6 @@ gcode:
    G1 E10 F300                    ; extrude a little to soften tip
    G1 E-40 F1800                  ; retract some, but not too much or it will jam
    M82                            ; set extruder to absolute
-
-##   Sensor Types
-##   "Trianglelab NTC100K B3950" (Beta 3950 used in LDO kits)
-##   "EPCOS 100K B57560G104F"
-##   "ATC Semitec 104GT-2"
-##   "Generic 3950"
-##   "Honeywell 100K 135-104LAG-J01"
-##   "NTC 100K MGB18-104F39050L32" (Keenovo Heater Pad)
-##   "AD595"
-##   "PT100 INA826"
-##   "PT1000"
-##   For more information: https://www.klipper3d.org/Config_Reference.html#temperature_sensor
 
 ## Footnote about Beta 3950:
 ## https://github.com/Klipper3d/klipper/issues/4054

--- a/Firmware/skr-pico-v1.0.cfg
+++ b/Firmware/skr-pico-v1.0.cfg
@@ -279,7 +279,3 @@ gcode:
    G1 E10 F300                    ; extrude a little to soften tip
    G1 E-40 F1800                  ; retract some, but not too much or it will jam
    M82                            ; set extruder to absolute
-
-## Footnote about Beta 3950:
-## https://github.com/Klipper3d/klipper/issues/4054
-## https://github.com/Klipper3d/klipper/pull/4859


### PR DESCRIPTION
- Remove default `sensor_type:` values to ensure that users are verifying their thermistors. Many users are just using the default values without actually checking.
- Add comments linking to Klipper thermistor list (so always up-to-date)
- Remove thermistor list at bottom of config files (if it exists - better to use the always up-to-date Klipper link)
- Hint at using "Generic 3950" for NTC 100k 3950, and also for Keenovo heaters
- Remove custom 3950 definition (if exists) - no longer necessary, Klipper thermistor accuracy bug has been fixed, and any new builders will be pulling a new version of Klipper.