### PR TITLE
Update configs for LDO 36STH20-1004AHG

### DIFF
--- a/Firmware/skr-mini-E3-v2.0.cfg
+++ b/Firmware/skr-mini-E3-v2.0.cfg
@@ -157,6 +157,8 @@ interpolate: False
 #run_current: 0.5   # for OMC 14HR07-1004VRN rated at 1A
 ## For LDO LDO 36STH17-1004AHG 1A 1.8° 
 #run_current: 0.3   # for LDO 36STH17-1004AHG
+## For LDO LDO 36STH20-1004AHG 1A 1.8° 
+#run_current: 0.6   # for LDO 36STH20-1004AHG
 sense_resistor: 0.110
 stealthchop_threshold: 0                                            # Set to 0 for spreadcycle, avoid using stealthchop on extruder
 

--- a/Firmware/skr-mini-E3-v3.0.cfg
+++ b/Firmware/skr-mini-E3-v3.0.cfg
@@ -155,6 +155,8 @@ interpolate: False
 #run_current: 0.5   # for OMC 14HR07-1004VRN rated at 1A
 ## For LDO LDO 36STH17-1004AHG 1A 1.8° 
 #run_current: 0.3   # for LDO 36STH17-1004AHG
+## For LDO LDO 36STH20-1004AHG 1A 1.8° 
+#run_current: 0.6   # for LDO 36STH20-1004AHG
 sense_resistor: 0.110
 stealthchop_threshold: 0                                            # Set to 0 for spreadcycle, avoid using stealthchop on extruder
 

--- a/Firmware/skr-pico-v1.0.cfg
+++ b/Firmware/skr-pico-v1.0.cfg
@@ -155,6 +155,8 @@ interpolate: False
 #run_current: 0.5 # for OMC 14HR07-1004VRN rated at 1A
 ## For LDO LDO 36STH17-1004AHG 1A 1.8° 
 #run_current: 0.3 # for LDO 36STH17-1004AHG
+## For LDO LDO 36STH20-1004AHG 1A 1.8° 
+#run_current: 0.6 # for LDO 36STH20-1004AHG
 sense_resistor: 0.110
 stealthchop_threshold: 0                                            # Set to 0 for spreadcycle, avoid using stealthchop on extruder
 


### PR DESCRIPTION
* Add run_current for 36STH20-1004AHG, which replaces 36STH17-1004AHG in newer LDO kits.