### PR TITLE
Update skr-mini-E3-v2.0.cfg

### DIFF
--- a/Firmware/skr-mini-E3-v2.0.cfg
+++ b/Firmware/skr-mini-E3-v2.0.cfg
@@ -47,11 +47,11 @@ enable_pin: !PB14
 rotation_distance: 40
 microsteps: 32
 full_steps_per_rotation: 200                                        # Set to 400 for 0.9° degree stepper motor, 200 is for 1.8° stepper motors
-endstop_pin: ^PC0 
+endstop_pin: tmc2209_stepper_x:virtual_endstop
 position_endstop: 120
 position_max: 120
 homing_speed: 50                                                    # Can be increased after initial setup, Max 100
-homing_retract_dist: 5
+homing_retract_dist: 0
 homing_positive_dir: true
 
 [tmc2209 stepper_x]
@@ -62,6 +62,8 @@ interpolate: False
 run_current: 0.5
 sense_resistor: 0.110
 stealthchop_threshold: 0                                            # Set to 999999 to turn stealthchop on, and 0 to use spreadcycle
+diag_pin: ^PC0  													 
+driver_SGTHRS: 255 
 
 [stepper_y]
 step_pin: PB10
@@ -71,11 +73,11 @@ enable_pin: !PB11
 rotation_distance: 40
 microsteps: 32
 full_steps_per_rotation: 200                                        # Set to 400 for 0.9° degree stepper motor, 200 is for 1.8° stepper motors
-endstop_pin: ^PC1
+endstop_pin: tmc2209_stepper_x:virtual_endstop
 position_endstop: 120
 position_max: 120
 homing_speed: 50                                                    # Can be increased after initial setup, Max 100
-homing_retract_dist: 5
+homing_retract_dist: 0
 homing_positive_dir: true
 
 [tmc2209 stepper_y]
@@ -86,6 +88,8 @@ interpolate: False
 run_current: 0.5
 sense_resistor: 0.110
 stealthchop_threshold: 0                                            # Set to 999999 to turn stealthchop on, and 0 to use spreadcycle
+diag_pin: ^PC1  													 
+driver_SGTHRS: 255 
 
 #####################################################################
 #   Z Stepper Settings
@@ -98,7 +102,7 @@ enable_pin: !PB1
 rotation_distance: 8                                                # For T8x8 integrated lead screw
 microsteps: 32
 endstop_pin: ^PC2
-position_endstop: -0.10
+position_endstop: 120
 position_max: 120
 position_min: -1.5
 homing_speed: 10


### PR DESCRIPTION
sensorless homing missing