### PR TITLE
Update README.md link to Voron V0.2 page

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ![Image of Voron Zero](http://vorondesign.com/images/voron0.2_bg.jpg)
 
-The official release of the Voron Zero 3D printer. You can find the BOM in the configurator located at the [Voron Design]( http://vorondesign.com/voron0) website.
+The official release of the Voron Zero 3D printer. You can find the BOM in the configurator located at the [Voron Design]( http://vorondesign.com/voron0.2) website.
 
 The current revision is V0.2
 


### PR DESCRIPTION
The link to the Voron Design page for V0.2 should point at https://vorondesign.com/voron0.2 instead of https://vorondesign.com/voron0.