### PR TITLE
Fix syntax error in _HOME_Z and remove xy moves

### DIFF
--- a/Firmware/bigtreetech-manta-m4p.cfg
+++ b/Firmware/bigtreetech-manta-m4p.cfg
@@ -391,17 +391,12 @@ gcode:
     SET_TMC_CURRENT STEPPER=stepper_y CURRENT={RUN_CURRENT_Y}
 
 [gcode_macro _HOME_Z]
-    gcode:
+gcode:
     {% set th = printer.toolhead %}
     {% set RUN_CURRENT_Z = printer.configfile.settings['tmc2209 stepper_z'].run_current|float %}
     {% set HOME_CURRENT = 0.7 %}
     SET_TMC_CURRENT STEPPER=stepper_z CURRENT={HOME_CURRENT}
     G90
-    {% if 'x' or 'y' not in th.homed_axes %}
     G28 Z
-    {% else %}
-    G0 X{th.axis_maximum.x//2} Y{th.axis_maximum.y//2} F3600
-    G28 Z
-    {% endif %}
     G1 Z30
     SET_TMC_CURRENT STEPPER=stepper_z CURRENT={RUN_CURRENT_Z}

--- a/Firmware/bigtreetech-skr-3-ez.cfg
+++ b/Firmware/bigtreetech-skr-3-ez.cfg
@@ -435,17 +435,12 @@ gcode:
     SET_TMC_CURRENT STEPPER=stepper_y CURRENT={RUN_CURRENT_Y}
 
 [gcode_macro _HOME_Z]
-    gcode:
+gcode:
     {% set th = printer.toolhead %}
     {% set RUN_CURRENT_Z = printer.configfile.settings['tmc2209 stepper_z'].run_current|float %}
     {% set HOME_CURRENT = 0.7 %}
     SET_TMC_CURRENT STEPPER=stepper_z CURRENT={HOME_CURRENT}
     G90
-    {% if 'x' or 'y' not in th.homed_axes %}
     G28 Z
-    {% else %}
-    G0 X{th.axis_maximum.x//2} Y{th.axis_maximum.y//2} F3600
-    G28 Z
-    {% endif %}
     G1 Z30
     SET_TMC_CURRENT STEPPER=stepper_z CURRENT={RUN_CURRENT_Z}

--- a/Firmware/bigtreetech-skr-mini-e3-v2.0.cfg
+++ b/Firmware/bigtreetech-skr-mini-e3-v2.0.cfg
@@ -353,17 +353,12 @@ gcode:
     SET_TMC_CURRENT STEPPER=stepper_y CURRENT={RUN_CURRENT_Y}
 
 [gcode_macro _HOME_Z]
-    gcode:
+gcode:
     {% set th = printer.toolhead %}
     {% set RUN_CURRENT_Z = printer.configfile.settings['tmc2209 stepper_z'].run_current|float %}
     {% set HOME_CURRENT = 0.7 %}
     SET_TMC_CURRENT STEPPER=stepper_z CURRENT={HOME_CURRENT}
     G90
-    {% if 'x' or 'y' not in th.homed_axes %}
     G28 Z
-    {% else %}
-    G0 X{th.axis_maximum.x//2} Y{th.axis_maximum.y//2} F3600
-    G28 Z
-    {% endif %}
     G1 Z30
     SET_TMC_CURRENT STEPPER=stepper_z CURRENT={RUN_CURRENT_Z}

--- a/Firmware/bigtreetech-skr-mini-e3-v3.0.cfg
+++ b/Firmware/bigtreetech-skr-mini-e3-v3.0.cfg
@@ -406,17 +406,12 @@ gcode:
     SET_TMC_CURRENT STEPPER=stepper_y CURRENT={RUN_CURRENT_Y}
 
 [gcode_macro _HOME_Z]
-    gcode:
+gcode:
     {% set th = printer.toolhead %}
     {% set RUN_CURRENT_Z = printer.configfile.settings['tmc2209 stepper_z'].run_current|float %}
     {% set HOME_CURRENT = 0.7 %}
     SET_TMC_CURRENT STEPPER=stepper_z CURRENT={HOME_CURRENT}
     G90
-    {% if 'x' or 'y' not in th.homed_axes %}
     G28 Z
-    {% else %}
-    G0 X{th.axis_maximum.x//2} Y{th.axis_maximum.y//2} F3600
-    G28 Z
-    {% endif %}
     G1 Z30
     SET_TMC_CURRENT STEPPER=stepper_z CURRENT={RUN_CURRENT_Z}

--- a/Firmware/bigtreetech-skr-pico-v1.0.cfg
+++ b/Firmware/bigtreetech-skr-pico-v1.0.cfg
@@ -417,17 +417,12 @@ gcode:
     SET_TMC_CURRENT STEPPER=stepper_y CURRENT={RUN_CURRENT_Y}
 
 [gcode_macro _HOME_Z]
-    gcode:
+gcode:
     {% set th = printer.toolhead %}
     {% set RUN_CURRENT_Z = printer.configfile.settings['tmc2209 stepper_z'].run_current|float %}
     {% set HOME_CURRENT = 0.7 %}
     SET_TMC_CURRENT STEPPER=stepper_z CURRENT={HOME_CURRENT}
     G90
-    {% if 'x' or 'y' not in th.homed_axes %}
     G28 Z
-    {% else %}
-    G0 X{th.axis_maximum.x//2} Y{th.axis_maximum.y//2} F3600
-    G28 Z
-    {% endif %}
     G1 Z30
     SET_TMC_CURRENT STEPPER=stepper_z CURRENT={RUN_CURRENT_Z}

--- a/Firmware/fysetc-cheetah-v2.0.cfg
+++ b/Firmware/fysetc-cheetah-v2.0.cfg
@@ -416,17 +416,12 @@ gcode:
     SET_TMC_CURRENT STEPPER=stepper_y CURRENT={RUN_CURRENT_Y}
 
 [gcode_macro _HOME_Z]
-    gcode:
+gcode:
     {% set th = printer.toolhead %}
     {% set RUN_CURRENT_Z = printer.configfile.settings['tmc2209 stepper_z'].run_current|float %}
     {% set HOME_CURRENT = 0.7 %}
     SET_TMC_CURRENT STEPPER=stepper_z CURRENT={HOME_CURRENT}
     G90
-    {% if 'x' or 'y' not in th.homed_axes %}
     G28 Z
-    {% else %}
-    G0 X{th.axis_maximum.x//2} Y{th.axis_maximum.y//2} F3600
-    G28 Z
-    {% endif %}
     G1 Z30
     SET_TMC_CURRENT STEPPER=stepper_z CURRENT={RUN_CURRENT_Z}

--- a/Firmware/mellow-fly-gemini-v2.cfg
+++ b/Firmware/mellow-fly-gemini-v2.cfg
@@ -414,17 +414,12 @@ gcode:
     SET_TMC_CURRENT STEPPER=stepper_y CURRENT={RUN_CURRENT_Y}
 
 [gcode_macro _HOME_Z]
-    gcode:
+gcode:
     {% set th = printer.toolhead %}
     {% set RUN_CURRENT_Z = printer.configfile.settings['tmc2209 stepper_z'].run_current|float %}
     {% set HOME_CURRENT = 0.7 %}
     SET_TMC_CURRENT STEPPER=stepper_z CURRENT={HOME_CURRENT}
     G90
-    {% if 'x' or 'y' not in th.homed_axes %}
     G28 Z
-    {% else %}
-    G0 X{th.axis_maximum.x//2} Y{th.axis_maximum.y//2} F3600
-    G28 Z
-    {% endif %}
     G1 Z30
     SET_TMC_CURRENT STEPPER=stepper_z CURRENT={RUN_CURRENT_Z}


### PR DESCRIPTION
- Fixes a typo that causes a parse error in the new _HOME_Z macro
- Removes code to center the toolhead before homing Z

Rationale:
 - There's no reason to move X or Y during a Z home, since the toolhead is not required (or in the way) during homing Z.
 - Because there is no reason for it, to do it would be "unexpected behaviour"
 - it risks dragging the nozzle across the bed, potentially doing damage.
 
 