### PR TITLE
Up homing speed to 40mm/s

### DIFF
--- a/Firmware/bigtreetech-manta-m4p.cfg
+++ b/Firmware/bigtreetech-manta-m4p.cfg
@@ -54,7 +54,7 @@ full_steps_per_rotation: 200                                        # Set to 400
 endstop_pin: tmc2209_stepper_x:virtual_endstop                      # Using Virtual Endstop or sensorless homing, make sure you install the jumper on the controller under the stepper
 position_endstop: 120
 position_max: 120
-homing_speed: 20                                                    # for sensorless homing it is recommended not to go above 40mm/s  
+homing_speed: 40
 homing_retract_dist: 0
 
 [tmc2209 stepper_x]
@@ -77,7 +77,7 @@ full_steps_per_rotation: 200                                        # Set to 400
 endstop_pin: tmc2209_stepper_y:virtual_endstop  
 position_endstop: 120
 position_max: 120
-homing_speed: 20                                                    # for sensorless homing it is recommended not to go above 40mm/s  
+homing_speed: 40
 homing_retract_dist: 0
 
 [tmc2209 stepper_y]

--- a/Firmware/bigtreetech-skr-3-ez.cfg
+++ b/Firmware/bigtreetech-skr-3-ez.cfg
@@ -64,7 +64,7 @@ full_steps_per_rotation: 200                                        # Set to 400
 endstop_pin: tmc2209_stepper_x:virtual_endstop  
 position_endstop: 120
 position_max: 120
-homing_speed: 20                                                    # for sensorless homing it is recommended not to go above 40mm/s 
+homing_speed: 40
 homing_retract_dist: 0
 
 
@@ -89,7 +89,7 @@ full_steps_per_rotation: 200                                        # Set to 400
 endstop_pin: tmc2209_stepper_y:virtual_endstop  
 position_endstop: 120
 position_max: 120
-homing_speed: 20                                                    # for sensorless homing it is recommended not to go above 40mm/s 
+homing_speed: 40
 homing_retract_dist: 0
 
 [tmc2209 stepper_y]

--- a/Firmware/bigtreetech-skr-mini-e3-v2.0.cfg
+++ b/Firmware/bigtreetech-skr-mini-e3-v2.0.cfg
@@ -50,7 +50,7 @@ full_steps_per_rotation: 200                                        # Set to 400
 endstop_pin: tmc2209_stepper_x:virtual_endstop
 position_endstop: 120
 position_max: 120
-homing_speed: 20                                                    # for sensorless homing it is recommended not to go above 40mm/s   
+homing_speed: 40
 homing_retract_dist: 0
 homing_positive_dir: true
 
@@ -77,7 +77,7 @@ full_steps_per_rotation: 200                                        # Set to 400
 endstop_pin: tmc2209_stepper_y:virtual_endstop
 position_endstop: 120
 position_max: 120
-homing_speed: 20                                                    # for sensorless homing it is recommended not to go above 40mm/s   
+homing_speed: 40
 homing_retract_dist: 0
 homing_positive_dir: true
 

--- a/Firmware/bigtreetech-skr-mini-e3-v3.0.cfg
+++ b/Firmware/bigtreetech-skr-mini-e3-v3.0.cfg
@@ -59,7 +59,7 @@ full_steps_per_rotation: 200                                        # Set to 400
 endstop_pin: tmc2209_stepper_x:virtual_endstop 
 position_endstop: 120
 position_max: 120
-homing_speed: 20                                                    # for sensorless homing it is recommended not to go above 40mm/s   
+homing_speed: 40
 homing_retract_dist: 0
 
 [tmc2209 stepper_x]
@@ -85,7 +85,7 @@ full_steps_per_rotation: 200                                        # Set to 400
 endstop_pin: tmc2209_stepper_y:virtual_endstop
 position_endstop: 120
 position_max: 120
-homing_speed: 20                                                    # for sensorless homing it is recommended not to go above 40mm/s   
+homing_speed: 40
 homing_retract_dist: 0
 homing_positive_dir: true
 

--- a/Firmware/bigtreetech-skr-pico-v1.0.cfg
+++ b/Firmware/bigtreetech-skr-pico-v1.0.cfg
@@ -61,7 +61,7 @@ full_steps_per_rotation: 200                                        # Set to 400
 endstop_pin: tmc2209_stepper_x:virtual_endstop
 position_endstop: 120
 position_max: 120
-homing_speed: 20                                                    # for sensorless homing it is recommended not to go above 40mm/s   
+homing_speed: 40
 homing_retract_dist: 0
 homing_positive_dir: true
 
@@ -88,7 +88,7 @@ full_steps_per_rotation: 200                                        # Set to 400
 endstop_pin: tmc2209_stepper_y:virtual_endstop
 position_endstop: 120
 position_max: 120
-homing_speed: 20                                                    # for sensorless homing it is recommended not to go above 40mm/s   
+homing_speed: 40
 homing_retract_dist: 0
 homing_positive_dir: true
 

--- a/Firmware/fysetc-cheetah-v2.0.cfg
+++ b/Firmware/fysetc-cheetah-v2.0.cfg
@@ -59,7 +59,7 @@ full_steps_per_rotation: 200                                        # Set to 400
 endstop_pin: tmc2209_stepper_x:virtual_endstop
 position_endstop: 120
 position_max: 120
-homing_speed: 20                                                    # for sensorless homing it is recommended not to go above 40mm/s
+homing_speed: 40
 homing_retract_dist: 0
 homing_positive_dir: true
 
@@ -87,7 +87,7 @@ full_steps_per_rotation: 200                                        # Set to 400
 endstop_pin: tmc2209_stepper_y:virtual_endstop
 position_endstop: 120
 position_max: 120
-homing_speed: 20                                                    # for sensorless homing it is recommended not to go above 40mm/s
+homing_speed: 40
 homing_retract_dist: 0
 homing_positive_dir: true
 

--- a/Firmware/fysetc-cheetah-v3.0.cfg
+++ b/Firmware/fysetc-cheetah-v3.0.cfg
@@ -100,7 +100,7 @@ full_steps_per_rotation: 200                                        # Set to 400
 endstop_pin: tmc2209_stepper_x:virtual_endstop                      # Enable if using Sensorless homing - Disable if not. 
 position_endstop: 120
 position_max: 120
-homing_speed: 20                                                    # for sensorless homing it is recommended not to go above 40mm/s
+homing_speed: 40
 homing_retract_dist: 0
 homing_positive_dir: true
 
@@ -131,7 +131,7 @@ full_steps_per_rotation: 200                                        # Set to 400
 endstop_pin: tmc2209_stepper_y:virtual_endstop                      # Enable if using Sensorless homing - Disable if not.
 position_endstop: 120
 position_max: 120
-homing_speed: 20                                                    # for sensorless homing it is recommended not to go above 40mm/s
+homing_speed: 40
 homing_retract_dist: 0
 homing_positive_dir: true
 

--- a/Firmware/mellow-fly-gemini-v2.cfg
+++ b/Firmware/mellow-fly-gemini-v2.cfg
@@ -57,7 +57,7 @@ full_steps_per_rotation: 200                                        # Set to 400
 endstop_pin: tmc2209_stepper_x:virtual_endstop
 position_endstop: 120
 position_max: 120
-homing_speed: 40                                                    # for sensorless homing it is recommended not to go above 40mm/s   
+homing_speed: 40
 homing_retract_dist: 0
 homing_positive_dir: true
 
@@ -82,7 +82,7 @@ full_steps_per_rotation: 200                                        # Set to 400
 endstop_pin: tmc2209_stepper_y:virtual_endstop
 position_endstop: 120
 position_max: 120
-homing_speed: 40                                                    # for sensorless homing it is recommended not to go above 40mm/s   
+homing_speed: 40
 homing_retract_dist: 0
 homing_positive_dir: true
 

--- a/Firmware/mellow-fly-gemini-v3.cfg
+++ b/Firmware/mellow-fly-gemini-v3.cfg
@@ -57,7 +57,7 @@ full_steps_per_rotation: 200                                        # Set to 400
 endstop_pin: tmc2209_stepper_x:virtual_endstop
 position_endstop: 120
 position_max: 120
-homing_speed: 40                                                    # for sensorless homing it is recommended not to go above 40mm/s   
+homing_speed: 40
 homing_retract_dist: 0
 homing_positive_dir: true
 
@@ -82,7 +82,7 @@ full_steps_per_rotation: 200                                        # Set to 400
 endstop_pin: tmc2209_stepper_y:virtual_endstop
 position_endstop: 120
 position_max: 120
-homing_speed: 40                                                    # for sensorless homing it is recommended not to go above 40mm/s   
+homing_speed: 40
 homing_retract_dist: 0
 homing_positive_dir: true
 


### PR DESCRIPTION
Bump up sensorless homing speed to 40mm/s as the TMC2209 documentation states: 

> Very low motor velocities (for many motors well below one revolution per second) generate low back EMF and make the measurement unstable and dependent on motor and IC production stray

With 40mm/s it will result to 1 rotation per second. Currently it's just half a rotation per second.

The Fly Gemini configs had the homing speed already at 40mm/s removed the comment there about the homing speed to not go over 40mm/s